### PR TITLE
Initial allocation implementation (with functionality to share a single resgroup amongs containers)

### DIFF
--- a/configs/mesos_example_allocator.yaml
+++ b/configs/mesos_example_allocator.yaml
@@ -18,13 +18,13 @@ runner: !AllocationRunner
   ignore_privileges_check: true
   node: !MesosNode
     mesos_agent_endpoint: 'http://127.0.0.1:5051'
-  action_delay: 1.
+  action_delay: 2.
   metrics_storage: !LogStorage
     output_filename: metrics.logs
   anomalies_storage: !LogStorage
     output_filename: anomalies.logs
   allocations_storage: !LogStorage
     output_filename: allocations.logs
-  allocator: !ExampleAllocator
+  allocator: !TestingAllocator
   rdt_enabled: true
   allocation_configuration: !AllocationConfiguration

--- a/configs/mesos_example_allocator.yaml
+++ b/configs/mesos_example_allocator.yaml
@@ -1,0 +1,30 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# Basic minimal configuration to dump metrics on stderr with NOPAnomaly detector
+runner: !AllocationRunner
+  ignore_privileges_check: true
+  node: !MesosNode
+    mesos_agent_endpoint: 'http://127.0.0.1:5051'
+  action_delay: 1.
+  metrics_storage: !LogStorage
+    output_filename: metrics.logs
+  anomalies_storage: !LogStorage
+    output_filename: anomalies.logs
+  allocations_storage: !LogStorage
+    output_filename: allocations.logs
+  allocator: !ExampleAllocator
+  rdt_enabled: true
+  allocation_configuration: !AllocationConfiguration

--- a/docs/detection.rst
+++ b/docs/detection.rst
@@ -28,9 +28,8 @@ You can configure system to detect and report anomalies in following way in ``co
 
     runner: !DetectionRunner
       node: !MesosNode
-      metrics_storage: !KafkaStorage            # used for storing all inputs of detection algorithm
-      anomalies_storage: !KafkaStorage          # used for storing all outputs of detection algorithm
-      action_delay: 1.                          # [s]
+      storage: !KafkaStorage                    # used for storing all inputs and outputs
+      delay: 1.                                 # [s]
       detector: !ContentionAnomalyDetector      # implementation of abstract AnomalyDetector class
         example_config_int: 1
         example_config_list: [1, 4]
@@ -45,8 +44,7 @@ You can configure system to detect and report anomalies in following way in ``co
         def detect(self,
                     platform: Platform,
                     tasks_measurements: TasksMeasurements,
-                    tasks_resources: TasksResources,
-                    tasks_labels: TasksLabels,
+                    tasks_resources: TasksResources
                     ) -> (List[Anomaly], List[Metric]):
             ...
 
@@ -64,7 +62,6 @@ Example implementation:
         def detect(self, platform: Platform,
                          tasks_measurements: TasksMeasurements,
                          tasks_resources: TasksResources,
-                         tasks_labels: TasksLabels,
                          ) -> (List[Anomaly], List[Metric]):
             return [], []
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -108,6 +108,16 @@ You can run without building a distribution like this:
     
     sudo env PYTHONPATH=. `which python3.6` owca/main.py -c configs/mesos_example.yaml --root
 
+
+Using example allocator:
+
+
+.. code-block:: shell
+
+    python3.6 -mpipenv shell
+    ulimit -n 10000
+    PYTHONPATH=. python owca/main.py -c configs/mesos_example_allocator.yaml -0 -linfo -r example.external_package:ExampleAllocator -l example:debug
+
 Fast distribution rebuild
 -------------------------
 

--- a/example/external_package.py
+++ b/example/external_package.py
@@ -19,6 +19,7 @@ import hashlib
 from owca.metrics import Metric
 from owca.detectors import (TasksMeasurements, ContentionAnomaly,
                             ContendedResource, AnomalyDetector, TasksResources, TasksLabels)
+from owca.allocators import Allocator, AllocationType, RDTAllocation
 from owca.platforms import Platform
 
 import logging
@@ -140,3 +141,19 @@ class ExampleDetector(AnomalyDetector):
         ]
 
         return anomalies, debugging_metrics
+
+
+class ExampleAllocator(Allocator):
+
+    def allocate(self, platform, tasks_measurements, tasks_resources,
+                 tasks_labels, tasks_allocations):
+        log.debug('allocated called with tasks_allocations: %r', tasks_allocations)
+
+        if tasks_measurements:
+            task_id = list(tasks_measurements.keys())[0]
+            tasks_allocations[task_id] = {
+                AllocationType.QUOTA: 0.5,
+                AllocationType.RDT: RDTAllocation(l3='L3:0=ffff0;1=ffff0'),
+            }
+
+        return tasks_allocations, [], []

--- a/integration_tests/test_resctrl.py
+++ b/integration_tests/test_resctrl.py
@@ -1,0 +1,147 @@
+from owca.resctrl import ResGroup
+from owca.allocators import RDTAllocation
+
+import subprocess
+import re
+import time
+
+
+def if_file_contains(filepath, patterns):
+    # check if array is passed
+    if type(patterns) == str:
+        patterns = [patterns]
+
+    with open(filepath) as ffile:
+        content = " ".join(ffile.readlines())
+        for pattern in patterns:
+            if pattern not in content:
+                return False
+        return True
+
+
+class SampleProcess:
+    def __init__(self):
+        p_ = subprocess.Popen(re.split(r"\s+", "stress-ng --stream 1 -v"),
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.PIPE)
+        self.p_ = p_
+        time.sleep(1)
+
+    def is_alive(self):
+        return self.p_.poll() is None
+
+    def get_pid(self):
+        """get root pid"""
+        return str(self.p_.pid)
+
+    def get_pids(self):
+        """the main process and children processes"""
+        _pid = str(self.p_.pid)
+        children = subprocess.check_output("pgrep -P {}".format(_pid).split()).decode('utf-8').split()
+        return [_pid] + children
+
+    def kill(self):
+        self.p_.terminate()
+        while self.is_alive():
+            time.sleep(0.3)
+
+
+def test_simple():
+    """Creates one stress-ng process.
+       Creates new resctrl group with the pid of the process."""
+    stressng_ = SampleProcess()
+    assert stressng_.is_alive()
+    resgroup_ = ResGroup('grupa_szymona')
+    resgroup_.add_tasks([], 'mongrupa_januszka')
+    resgroup_.cleanup()
+
+    # pids are in the files
+    resgroup_.add_tasks(stressng_.get_pids(), 'mongrupa_januszka')
+    assert if_file_contains('/sys/fs/resctrl/grupa_szymona/tasks', stressng_.get_pids())
+    assert if_file_contains('/sys/fs/resctrl/grupa_szymona/mon_groups/mongrupa_januszka/tasks', stressng_.get_pid())
+
+    # set and check rdt allocations
+    l3_ = ('L3:0=000ff;1=000ff', 'L3:0=00fff;1=00fff')
+    for i in range(2):
+        task_allocations = { 
+            'cpu_quota': 0.6,
+            'cpu_shares': 0.8,
+            'rdt': RDTAllocation(name='hp_group', l3=l3_[i])
+        }
+        resgroup_.perform_allocations(task_allocations)
+        assert resgroup_.get_allocations()['rdt'].l3.strip() == l3_[i]
+        assert if_file_contains('/sys/fs/resctrl/grupa_szymona/schemata', l3_[i])
+
+    # pids are not longer in the tasks files
+    resgroup_.remove_tasks('mongrupa_januszka')
+    assert not if_file_contains('/sys/fs/resctrl/grupa_szymona/tasks', stressng_.get_pid())
+
+    # but still available in root ctrlgroup
+    assert if_file_contains('/sys/fs/resctrl/tasks', stressng_.get_pid())
+    assert stressng_.is_alive()
+
+    # cleanup
+    stressng_.kill()
+    assert not stressng_.is_alive()
+
+    assert not if_file_contains('/sys/fs/resctrl/tasks', stressng_.get_pid())
+    resgroup_.cleanup()
+
+
+def test_complex_1():
+    """Move tasks between resctrl groups. """
+    p0, p1, p2 = SampleProcess(), SampleProcess(), SampleProcess()
+    processes = [p0, p1, p2]
+
+    assert all(p.is_alive() for p in processes)
+
+    resgroups = [ResGroup('g0'), ResGroup('g1')]
+    g0, g1 = resgroups
+    for rg in resgroups:
+        rg.cleanup()
+
+    # p0 and p1 to r0
+    g0.add_tasks(p0.get_pids(), 'p0')
+    g0.add_tasks(p1.get_pids(), 'p1')
+
+    # p2 to r1
+    g1.add_tasks(p2.get_pids(), 'p2')
+
+    # check ctrl cgroups pids
+    assert if_file_contains('/sys/fs/resctrl/g0/tasks', p0.get_pids())
+    assert if_file_contains('/sys/fs/resctrl/g0/tasks', p1.get_pids())
+    assert if_file_contains('/sys/fs/resctrl/g1/tasks', p2.get_pids())
+
+    # move p1 from g0 to g1
+    g0.remove_tasks('p1')
+    g1.add_tasks(p1.get_pids(), 'p1')
+
+    # g0/p0 still contains p0
+    assert if_file_contains('/sys/fs/resctrl/g0/tasks', p0.get_pids())
+    assert if_file_contains('/sys/fs/resctrl/g0/mon_groups/p0/tasks', p0.get_pids())
+
+    # there is no g0/p1 anymore
+    # p1 is in g1/p1 now
+    assert if_file_contains('/sys/fs/resctrl/g1/tasks', p1.get_pids())
+    assert if_file_contains('/sys/fs/resctrl/g1/mon_groups/p1/tasks', p1.get_pids())
+
+    # p2 is still in g1/p2
+    assert if_file_contains('/sys/fs/resctrl/g1/tasks', p2.get_pids())
+    assert if_file_contains('/sys/fs/resctrl/g1/mon_groups/p2/tasks', p2.get_pids())
+
+    for p in processes:
+        p.kill()
+
+    time.sleep(1)
+    for p in processes:
+        assert not p.is_alive()
+
+    assert not if_file_contains('/sys/fs/resctrl/g0/tasks', p0.get_pid())
+    assert not if_file_contains('/sys/fs/resctrl/g0/mon_groups/p0/tasks', p0.get_pid())
+    assert not if_file_contains('/sys/fs/resctrl/g1/tasks', p1.get_pid())
+    assert not if_file_contains('/sys/fs/resctrl/g1/mon_groups/p1/tasks', p1.get_pid())
+    assert not if_file_contains('/sys/fs/resctrl/g1/tasks', p2.get_pid())
+    assert not if_file_contains('/sys/fs/resctrl/g1/mon_groups/p2/tasks', p2.get_pid())
+
+    for rg in resgroups:
+        rg.cleanup()

--- a/owca/allocators.py
+++ b/owca/allocators.py
@@ -21,6 +21,9 @@ from owca.metrics import Metric
 from owca.mesos import TaskId
 from owca.platforms import Platform
 from owca.detectors import TasksMeasurements, TasksResources, TasksLabels, Anomaly
+import logging
+
+log = logging.getLogger(__name__)
 
 
 class AllocationType(str, Enum):
@@ -78,6 +81,57 @@ class NOPAllocator(Allocator):
     def allocate(self, platform, tasks_measurements, tasks_resources,
                  tasks_labels, tasks_allocations):
         return [], [], []
+
+
+# @TODO remove from code
+class TestingAllocator(Allocator):
+    def __init__(self):
+        self.testing_allocator_mode_index = 0
+        self.testing_allocator_modes = ['empty', 
+                                        'one_group', 
+                                        'seperate_group', 
+                                        'all_in_root_group', 
+                                        'empty']
+
+    def allocate(
+            self,
+            platform: Platform,
+            tasks_measurements: TasksMeasurements,
+            tasks_resources: TasksResources,
+            tasks_labels: TasksLabels,
+            tasks_allocations: TasksAllocations,
+    ) -> (TasksAllocations, List[Anomaly], List[Metric]):
+        testing_allocator_mode = self.testing_allocator_modes[self.testing_allocator_mode_index]
+        log.debug('TestingAllocator mode is {}'.format(testing_allocator_mode))
+        self.testing_allocator_mode_index = (self.testing_allocator_mode_index + 1)
+        if self.testing_allocator_mode_index == 5:
+            exit(1)
+
+        new_tasks_allocations = {}
+        if testing_allocator_mode == 'empty':
+            return [], [], []
+        elif testing_allocator_mode == 'one_group':
+            for task_id in tasks_resources:
+                new_tasks_allocations[task_id] = {
+                    AllocationType.QUOTA: 1000,
+                    AllocationType.RDT: RDTAllocation(name='only_group', l3='L3:0=00fff;1=0ffff')
+                }
+        elif testing_allocator_mode == 'seperate_group':
+            for task_id in tasks_resources:
+                new_tasks_allocations[task_id] = {
+                    AllocationType.QUOTA: 2000,
+                    AllocationType.RDT: RDTAllocation()
+                }
+        elif testing_allocator_mode == 'all_in_root_group':
+            for task_id in tasks_resources:
+                new_tasks_allocations[task_id] = {
+                    AllocationType.QUOTA: 2000,
+                    AllocationType.RDT: RDTAllocation(name='')
+                }
+
+        return (new_tasks_allocations, [], [])
+
+
 
 # -----------------------------------------------------------------------
 # private logic to handle allocations

--- a/owca/allocators.py
+++ b/owca/allocators.py
@@ -15,7 +15,7 @@
 from abc import ABC, abstractmethod
 from dataclasses import dataclass
 from enum import Enum
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Tuple, Optional
 
 from owca.metrics import Metric
 from owca.mesos import TaskId
@@ -48,12 +48,15 @@ TasksAllocations = Dict[TaskId, TaskAllocations]
 class AllocationConfiguration:
 
     # Default value for cpu.cpu_period [ms] (used as denominator).
-    cpu_quota_period: int = 100
+    cpu_quota_period: int = 1000
 
     # Number of minimum shares, when ``cpu_shares`` allocation is set to 0.0.
     cpu_shares_min: int = 2
     # Number of shares to set, when ``cpu_shares`` allocation is set to 1.0.
     cpu_shares_max: int = 10000
+
+    # Default Allocation for default root group
+    default_rdt_allocation: RDTAllocation = None
 
 
 class Allocator(ABC):
@@ -73,10 +76,91 @@ class Allocator(ABC):
 class NOPAllocator(Allocator):
 
     def allocate(self, platform, tasks_measurements, tasks_resources,
-                 tasks_labels, task_allocations):
+                 tasks_labels, tasks_allocations):
         return [], [], []
+
+# -----------------------------------------------------------------------
+# private logic to handle allocations
+# -----------------------------------------------------------------------
 
 
 def convert_allocations_to_metrics(allocations) -> List[Metric]:
     # TODO: convenrt allocations to metrics
     return []
+
+
+def _merge_rdt_allocation(old_rdt_allocation: Optional[RDTAllocation],
+                          new_rdt_allocation: RDTAllocation)\
+        -> Tuple[RDTAllocation, RDTAllocation]:
+    # new name, then new allocation will be used (overwrite) but no merge
+    if old_rdt_allocation is None or old_rdt_allocation.name != new_rdt_allocation.name:
+        return new_rdt_allocation, new_rdt_allocation
+    else:
+        all_rdt_allocation = RDTAllocation(
+            name=old_rdt_allocation.name,
+            l3=new_rdt_allocation.l3 or old_rdt_allocation.l3,
+            mb=new_rdt_allocation.mb or old_rdt_allocation.mb,
+         )
+        resulting_rdt_allocation = RDTAllocation(
+            name=new_rdt_allocation.name,
+            l3=new_rdt_allocation.l3,
+            mb=new_rdt_allocation.mb,
+        )
+        return all_rdt_allocation, resulting_rdt_allocation
+
+
+def _calculate_task_allocations(
+        old_task_allocations: TaskAllocations,
+        new_task_allocations: TaskAllocations)\
+        -> Tuple[TaskAllocations, TaskAllocations]:
+    """Return allocations difference on single task level.
+    all - are the sum of existing and new
+    resulting - are just new allocaitons
+    """
+    all_task_allocations: TaskAllocations = dict(old_task_allocations)
+    resulting_task_allocations: TaskAllocations = {}
+
+    for allocation_type, value in new_task_allocations.items():
+        # treat rdt diffrently
+        if allocation_type == AllocationType.RDT:
+            old_rdt_allocation = old_task_allocations.get(AllocationType.RDT)
+            all_rdt_allocation, resulting_rdt_allocation = \
+                _merge_rdt_allocation(old_rdt_allocation, value)
+            all_task_allocations[AllocationType.RDT] = all_rdt_allocation
+            resulting_task_allocations[AllocationType.RDT] = resulting_rdt_allocation
+        else:
+            all_task_allocations[allocation_type] = value
+
+    resulting_task_allocations: TaskAllocations = new_task_allocations
+    return all_task_allocations, resulting_task_allocations
+
+
+def _calculate_tasks_allocations(
+        old_tasks_allocations: TasksAllocations, new_tasks_allocations: TasksAllocations) \
+        -> Tuple[TasksAllocations, TasksAllocations]:
+    """Return all_allocations that are the effect on applied new_allocations on
+    old_allocations, additionally returning allocations that need to be applied just now.
+    """
+    all_tasks_allocations: TasksAllocations = {}
+    resulting_tasks_allocations: TasksAllocations = {}
+
+    # check and merge & overwrite with old allocations
+    for task_id, old_task_allocations in old_tasks_allocations.items():
+        if task_id in new_tasks_allocations:
+            new_task_allocations = new_tasks_allocations[task_id]
+            all_task_allocations, resulting_task_allocations = _calculate_task_allocations(
+                old_task_allocations, new_task_allocations)
+            all_tasks_allocations[task_id] = all_task_allocations
+            resulting_tasks_allocations[task_id] = resulting_task_allocations
+        else:
+            all_tasks_allocations[task_id] = old_task_allocations
+
+    # if there are any new_allocations on task level that yet not exists in old_allocations
+    # then just add them to both list
+    only_new_tasks_ids = set(new_tasks_allocations) - set(old_tasks_allocations)
+    for only_new_task_id in only_new_tasks_ids:
+        task_allocations = new_tasks_allocations[only_new_task_id]
+        all_tasks_allocations[only_new_task_id] = task_allocations
+        resulting_tasks_allocations[only_new_task_id] = task_allocations
+
+    return all_tasks_allocations, resulting_tasks_allocations

--- a/owca/cgroups.py
+++ b/owca/cgroups.py
@@ -11,16 +11,23 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-
+import logging
 import os
+from typing import Optional, List
 
 from dataclasses import dataclass
 
+from owca import logger
+from owca.allocators import TaskAllocations, AllocationType, AllocationConfiguration
 from owca.metrics import Measurements, MetricName
 
+log = logging.getLogger(__name__)
 
 CPU_USAGE = 'cpuacct.usage'
+CPU_QUOTA = 'cpu.cfs_quota_us'
+CPU_PERIOD = 'cpu.cfs_period_us'
+CPU_SHARES = 'cpu.shares'
+TASKS = 'tasks'
 BASE_SUBSYSTEM_PATH = '/sys/fs/cgroup/cpu'
 
 
@@ -28,6 +35,10 @@ BASE_SUBSYSTEM_PATH = '/sys/fs/cgroup/cpu'
 class Cgroup:
 
     cgroup_path: str
+
+    # Values used for normlization of allocations
+    platform_cpus: int  # required for quota normalization
+    allocation_configuration: Optional[AllocationConfiguration] = None
 
     def __post_init__(self):
         assert self.cgroup_path.startswith('/'), 'Provide cgroup_path with leading /'
@@ -41,3 +52,78 @@ class Cgroup:
             cpu_usage = int(cpu_usage_file.read())
 
         return {MetricName.CPU_USAGE_PER_TASK: cpu_usage}
+
+    def _read(self, cgroup_control_file: str) -> int:
+        """Read helper to store any and convert value from cgroup control file."""
+        with open(os.path.join(self.cgroup_fullpath, cgroup_control_file)) as f:
+            v = int(f.read())
+            log.log(logger.TRACE, 'cgroup: read %s=%r', f.name, v)
+            return v
+
+    def _write(self, cgroup_control_file: str, value: int):
+        """Write helper to store any int value in cgroup control file."""
+        with open(os.path.join(self.cgroup_fullpath, cgroup_control_file), 'wb') as f:
+            raw_value = bytes(str(value), encoding='utf8')
+            log.log(logger.TRACE, 'cgroup: write %s=%r', f.name, raw_value)
+            f.write(raw_value)
+
+    def _get_normalized_shares(self) -> float:
+        """Return normalized using cpu_shreas_min and cpu_shares_max for normalization."""
+        assert self.allocation_configuration is not None, \
+            'normalization configuration cannot be used without configuration!'
+        shares = self._read(CPU_SHARES)
+        return ((shares - self.allocation_configuration.cpu_shares_min) /
+                self.allocation_configuration.cpu_shares_max)
+
+    def _set_normalized_shares(self, shares_normalized):
+        """Store shares normalized values in cgroup files system. For denormalization
+        we use reverse formule to _get_normalized_shares."""
+        assert self.allocation_configuration is not None, \
+            'allocation configuration cannot be used without configuration!'
+        shares = ((shares_normalized * self.allocation_configuration.cpu_shares_max) +
+                  self.allocation_configuration.cpu_shares_min)
+        self._write(CPU_SHARES, shares)
+
+    def _get_normalized_quota(self) -> float:
+        """Read normlalized quota against configured period and number of available cpus."""
+        assert self.allocation_configuration is not None, \
+            'normalization configuration cannot be used without configuration!'
+        current_quota = self._read(CPU_QUOTA)
+        current_period = self._read(CPU_PERIOD)
+        if current_quota == -1:
+            return float('Inf')  # quota is not set (TODO: consider using 0)
+        # Period 0 is invalid arugment for cgroup cpu subsystem. so division is safe.
+        return current_quota / current_period / self.platform_cpus
+
+    def _set_normalized_quota(self, quota_normalized: float):
+        """Unconditionally sets quota and period if nessesary."""
+        assert self.allocation_configuration is not None, \
+            'allocation configuration cannot be used without configuration!'
+        current_period = self._read(CPU_PERIOD)
+
+        # synchornize quota if nessesary
+        if current_period != self.allocation_configuration.cpu_quota_period:
+            self._write(CPU_PERIOD, self.allocation_configuration.cpu_quota_period)
+        quota = int(quota_normalized * self.allocation_configuration.cpu_quota_period *
+                    self.platform_cpus)
+        self._write(CPU_QUOTA, quota)
+
+    def get_allocations(self) -> TaskAllocations:
+        assert self.allocation_configuration is not None, \
+            'reading normalized allocations is not possible without configuration!'
+        return {
+           AllocationType.QUOTA: self._get_normalized_quota(),
+           AllocationType.SHARES: self._get_normalized_shares(),
+        }
+
+    def perform_allocations(self, allocations: TaskAllocations):
+        assert self.allocation_configuration is not None, \
+            'performing normalized allocations is not possible without configuration!'
+        if AllocationType.QUOTA in allocations:
+            self._set_normalized_quota(allocations[AllocationType.QUOTA])
+        if AllocationType.SHARES in allocations:
+            self._set_normalized_shares(allocations[AllocationType.SHARES])
+
+    def get_tasks(self) -> List[int]:
+        with open(os.path.join(self.cgroup_fullpath, TASKS)) as f:
+            return list(map(int, f.read().splitlines()))

--- a/owca/components.py
+++ b/owca/components.py
@@ -32,6 +32,7 @@ def register_components(extra_components: List[str]):
     config.register(storage.KafkaStorage)
     config.register(detectors.NOPAnomalyDetector)
     config.register(allocators.NOPAllocator)
+    config.register(allocators.TestingAllocator)
     config.register(allocators.AllocationConfiguration)
 
     for component in extra_components:

--- a/owca/components.py
+++ b/owca/components.py
@@ -18,6 +18,7 @@ import pkg_resources
 
 from owca import config
 from owca import detectors
+from owca import allocators
 from owca import mesos
 from owca import runner
 from owca import storage
@@ -25,13 +26,16 @@ from owca import storage
 
 def register_components(extra_components: List[str]):
     config.register(runner.DetectionRunner)
+    config.register(runner.AllocationRunner)
     config.register(mesos.MesosNode)
     config.register(storage.LogStorage)
     config.register(storage.KafkaStorage)
     config.register(detectors.NOPAnomalyDetector)
+    config.register(allocators.NOPAllocator)
+    config.register(allocators.AllocationConfiguration)
 
     for component in extra_components:
         # Load external class ignored its requirements.
         ep = pkg_resources.EntryPoint.parse('external_cls=%s' % component)
-        cls = ep.load(require=False)
+        cls = ep.resolve()
         config.register(cls)

--- a/owca/containers.py
+++ b/owca/containers.py
@@ -13,15 +13,21 @@
 # limitations under the License.
 
 
-from typing import List
+from typing import List, Optional, Dict
+import logging
 
 from dataclasses import dataclass
 
+from owca import logger
+from owca.allocators import AllocationConfiguration, TaskAllocations, TasksAllocations, \
+    _calculate_tasks_allocations
+from owca.nodes import Task
 from owca.resctrl import ResGroup
 from owca.cgroups import Cgroup
 from owca.perf import PerfCounters
 from owca.metrics import Measurements, MetricName
 
+log = logging.getLogger(__name__)
 
 DEFAULT_EVENTS = (MetricName.INSTRUCTIONS, MetricName.CYCLES, MetricName.CACHE_MISSES)
 
@@ -36,25 +42,47 @@ def flatten_measurements(measurements: List[Measurements]):
     return all_measurements_flat
 
 
+def _convert_cgroup_path_to_resgroup_name(cgroup_path):
+    """Return resgroup compatbile name for cgroup path (remove special characters like /)."""
+    assert cgroup_path.startswith('/'), 'Provide cgroup_path with leading /'
+    # cgroup path without leading '/'
+    relative_cgroup_path = cgroup_path[1:]
+    # Resctrl group is flat so flatten then cgroup hierarchy.
+    return relative_cgroup_path.replace('/', '-')
+
+
 @dataclass
 class Container:
 
     cgroup_path: str
+    platform_cpus: int
+    allocation_configuration: Optional[AllocationConfiguration] = None
     rdt_enabled: bool = True
+    task_name: str = None  # defaults to flatten value of provided cgroup_path
 
     def __post_init__(self):
-        self.cgroup = Cgroup(self.cgroup_path)
+        self.cgroup = Cgroup(
+            self.cgroup_path,
+            platform_cpus=self.platform_cpus,
+            allocation_configuration=self.allocation_configuration,
+        )
+        self.task_name = self.task_name or _convert_cgroup_path_to_resgroup_name(self.cgroup_path)
         self.perf_counters = PerfCounters(self.cgroup_path, event_names=DEFAULT_EVENTS)
-        self.resgroup = ResGroup(self.cgroup_path) if self.rdt_enabled else None
+        self.resgroup = ResGroup(name=self.task_name) if self.rdt_enabled else None
+
+    def get_pids(self) -> List[int]:
+        return self.cgroup.get_tasks()
 
     def sync(self):
         if self.rdt_enabled:
-            self.resgroup.sync()
+            tasks = list(map(str, self.get_pids()))
+            log.debug('sync %d tasks to %r', len(tasks), self.task_name)
+            self.resgroup.add_tasks(tasks, self.task_name)
 
     def get_measurements(self) -> Measurements:
         return flatten_measurements([
             self.cgroup.get_measurements(),
-            self.resgroup.get_measurements() if self.rdt_enabled else {},
+            self.resgroup.get_measurements(self.task_name) if self.rdt_enabled else {},
             self.perf_counters.get_measurements(),
         ])
 
@@ -62,3 +90,145 @@ class Container:
         if self.rdt_enabled:
             self.resgroup.cleanup()
         self.perf_counters.cleanup()
+
+    def get_allocations(self) -> TaskAllocations:
+        # In only detect mode, without allocation configuration return nothing.
+        if not self.allocation_configuration:
+            return {}
+        allocations: TaskAllocations = dict()
+        allocations.update(self.cgroup.get_allocations())
+        if self.rdt_enabled:
+            allocations.update(self.resgroup.get_allocations())
+        return allocations
+
+    def perform_allocations(self, allocations: TaskAllocations):
+        self.cgroup.perform_allocations(allocations)
+        if self.rdt_enabled:
+            self.resgroup.perform_allocations(allocations)
+
+
+class ContainerManager:
+    """Main engine of synchornizing state between found orechestratios software tasks,
+    its containers and resctrl system.
+
+    - sync_container_state - is responsible for mapping Tasks to Container objects
+            and managing underlaying ResGroup objects
+    - sync_allocations - is responsible for applying TaskAllocations to underlaying
+            Cgroup and ResGroup objects
+
+    """
+
+    def __init__(self, rdt_enabled: bool, platform_cpus: int,
+                 allocation_configuration: Optional[AllocationConfiguration]):
+        self.containers: Dict[Task, Container] = {}
+        self.resgroups: Dict[ResGroup, List[Container]] = {}
+        self.rdt_enabled = rdt_enabled
+        self.platform_cpus = platform_cpus
+        self.allocation_configuration = allocation_configuration
+
+    def sync_containers_state(self, tasks) -> Dict[Task, Container]:
+        """Sync internal state of runner by removing orphaned containers, and creating containers
+        for newly arrived tasks, and synchronizing containers' state.
+
+        Function is responsible for cleaning or initializing measurements stateful subsystems
+        and their external resources, e.g.:
+        - perf counters opens file descriptors for counters,
+        - resctrl (ResGroups) creates and manages directories under resctrl fs and scarce "clsid"
+            hardware identifiers
+
+        """
+        # Find difference between discovered Mesos tasks and already watched containers.
+        new_tasks, containers_to_cleanup = _calculate_desired_state(
+            tasks, list(self.containers.values()))
+
+        if containers_to_cleanup:
+            log.debug('state: cleaning up %d containers', len(containers_to_cleanup))
+            log.log(logger.TRACE, 'state: containers_to_cleanup=%r', containers_to_cleanup)
+
+        # Cleanup and remove orphaned containers (cleanup).
+        for container_to_cleanup in containers_to_cleanup:
+            container_to_cleanup.cleanup()
+        self.containers = {task: container
+                           for task, container in self.containers.items()
+                           if task in tasks}
+
+        if new_tasks:
+            log.debug('state: found %d new tasks', len(new_tasks))
+            log.log(logger.TRACE, 'state: new_tasks=%r', new_tasks)
+
+        # Create new containers and store them.
+        for new_task in new_tasks:
+            self.containers[new_task] = Container(
+                new_task.cgroup_path,
+                rdt_enabled=self.rdt_enabled,
+                platform_cpus=self.platform_cpus,
+                allocation_configuration=self.allocation_configuration
+            )
+
+        # Sync state of individual containers.
+        for container in self.containers.values():
+            container.sync()
+
+        return self.containers
+
+    def _perfom_allocations(self, tasks_allocations):
+        for task, container in self.containers.items():
+            if task.task_id in tasks_allocations:
+                task_allocations = tasks_allocations[task.task_id]
+                container.perform_allocations(task_allocations)
+
+    def cleanup(self):
+        # cleanup
+        for container in self.containers.values():
+            container.cleanup()
+
+    def sync_allocations(self, old_allocations: TasksAllocations,
+                         new_allocations: TasksAllocations):
+        """After new allocations returned from allocate function, calculate the difference
+        between actual state and expected and execute nessesary steps to apply required changes
+        to system.
+        Required changes to system means:
+        - created if nesseasry RdtGroups
+
+
+        :param old_allocations:
+        :param new_allocations:
+        :return:
+        """
+        all_allocations, resulting_allocations = _calculate_tasks_allocations(
+                old_allocations, new_allocations)
+        log.log(logger.TRACE, 'Resulting allocations to execute: %r', resulting_allocations)
+
+        self._perfom_allocations(resulting_allocations)
+
+        return all_allocations
+
+
+def _calculate_desired_state(
+        discovered_tasks: List[Task], known_containers: List[Container]
+) -> (List[Task], List[Container]):
+    """Prepare desired state of system by comparing actual running Mesos tasks and already
+    watched containers.
+
+    Assumptions:
+    * One-to-one relationship between task and container
+    * cgroup_path for task and container need to be identical to establish the relationship
+    * cgroup_path is unique for each task
+
+    :returns "list of Mesos tasks to start watching" and "orphaned containers to cleanup" (there are
+    no more Mesos tasks matching those containers)
+    """
+    discovered_task_cgroup_paths = {task.cgroup_path for task in discovered_tasks}
+    containers_cgroup_paths = {container.cgroup_path for container in known_containers}
+
+    # Filter out containers which are still running according to Mesos agent.
+    # In other words pick orphaned containers.
+    containers_to_delete = [container for container in known_containers
+                            if container.cgroup_path not in discovered_task_cgroup_paths]
+
+    # Filter out tasks which are monitored using "Container abstraction".
+    # In other words pick new, not yet monitored tasks.
+    new_tasks = [task for task in discovered_tasks
+                 if task.cgroup_path not in containers_cgroup_paths]
+
+    return new_tasks, containers_to_delete

--- a/owca/detectors.py
+++ b/owca/detectors.py
@@ -164,9 +164,22 @@ class NOPAnomalyDetector(AnomalyDetector):
 def convert_anomalies_to_metrics(anomalies: List[Anomaly]) -> List[Metric]:
     """Takes anomalies on input and convert them to something that can be
     stored persistently adding help/type fields and labels.
+    # Note: anomaly metrics include metrics found in ContentionAnomaly.metrics.
     """
     metrics = []
     for anomaly in anomalies:
         metrics.extend(anomaly.generate_metrics())
 
     return metrics
+
+
+def update_anomalies_metrics_with_task_information(anomaly_metrics: List[Metric],
+                                                   tasks_labels: Dict[str, Dict[str, str]],
+                                                   ):
+    for anomaly_metric in anomaly_metrics:
+        # Extra labels for anomaly metrics for information about task.
+        if 'contended_task_id' in anomaly_metric.labels:  # Only for anomaly metrics.
+            contended_task_id = anomaly_metric.labels['contended_task_id']
+            anomaly_metric.labels.update(
+                tasks_labels.get(contended_task_id, {})
+            )

--- a/owca/main.py
+++ b/owca/main.py
@@ -73,7 +73,7 @@ def main():
     log_levels.setdefault(logger.DEFAULT_MODULE, 'info')
     logger.configure_loggers_from_dict(log_levels)
 
-    log.warn('This software is pre-production and should not be deployed to production servers.')
+    log.warning('This software is pre-production and should not be deployed to production servers.')
     log.debug('started PID=%r', os.getpid())
     log.info('Version owca: %s', platforms.get_owca_version())
 
@@ -112,6 +112,7 @@ def main():
     runner = configuration['runner']
 
     # Prepare and run the "main loop".
+
     runner.run()
 
 

--- a/owca/resctrl.py
+++ b/owca/resctrl.py
@@ -18,9 +18,9 @@ import logging
 import os
 
 from owca import logger
-from owca.cgroups import BASE_SUBSYSTEM_PATH
+from owca.allocators import AllocationType, RDTAllocation
 from owca.metrics import Measurements, MetricName
-from owca.security import SetEffectiveRootUid
+# from owca.security import SetEffectiveRootUid  # TODO: where is the root handling ???
 
 BASE_RESCTRL_PATH = '/sys/fs/resctrl'
 MON_GROUPS = 'mon_groups'
@@ -31,6 +31,8 @@ MON_DATA = 'mon_data'
 MON_L3_00 = 'mon_L3_00'
 MBM_TOTAL = 'mbm_total_bytes'
 LLC_OCCUPANCY = 'llc_occupancy'
+RDT_MB = 'rdt_MB'
+RDT_LC = 'rdt_LC'
 
 
 log = logging.getLogger(__name__)
@@ -62,7 +64,7 @@ def cleanup_resctrl():
 
     # Remove all monitoring groups for both CLOS and RMID.
     _clean_taskless_folders(BASE_RESCTRL_PATH, '', resource_recycled='CLOS')
-    _clean_taskless_folders(BASE_RESCTRL_PATH, MON_GROUPS, resource_recycled='RMID')
+    # _clean_taskless_folders(BASE_RESCTRL_PATH, MON_GROUPS, resource_recycled='RMID')
 
 
 def check_resctrl():
@@ -96,67 +98,83 @@ def check_resctrl():
 
 
 class ResGroup:
+    """Represent a resctrl group.
+    If self.name == "" the object represents the root resctrl group.
+    """
 
-    def __init__(self, cgroup_path):
-        assert cgroup_path.startswith('/'), 'Provide cgroup_path with leading /'
-        relative_cgroup_path = cgroup_path[1:]  # cgroup path without leading '/'
-        self.cgroup_fullpath = os.path.join(
-            BASE_SUBSYSTEM_PATH, relative_cgroup_path)
-        # Resctrl group is flat so flatten then cgroup hierarchy.
-        flatten_rescgroup_name = relative_cgroup_path.replace('/', '-')
-        self.resgroup_dir = os.path.join(BASE_RESCTRL_PATH, MON_GROUPS, flatten_rescgroup_name)
-        self.resgroup_tasks = os.path.join(self.resgroup_dir, TASKS_FILENAME)
+    def __init__(self, name):
+        """Note: lazy create resctrl control group in add_tasks method."""
+        self.name = name
+        self.is_root_group = name == ""
+        self.fullpath = BASE_RESCTRL_PATH + ("/" + name if name != "" else "")
 
-    def sync(self, max_attempts=3):
-        """Copy all the tasks from all cgroups to resctrl tasks file
-        """
-        if not os.path.exists('/sys/fs/resctrl'):
-            log.warning('Resctrl not mounted, ignore sync!')
+    def is_root_group(self):
+        return self.is_root_group
+
+    def _get_mongroup_fullpath(self, mongroup_name):
+        return os.path.join(self.fullpath, MON_GROUPS, mongroup_name)
+
+    def _read_pids_from_tasks_file(self, tasks_filepath):
+        pids = []
+        with open(tasks_filepath) as ftasks:
+            for line in ftasks:
+                line = line.strip()
+                if line != "":
+                    pids.append(line)
+        return pids
+
+    def _add_pids_to_tasks_file(self, pids, tasks_filepath):
+        with open(tasks_filepath, 'w') as ftasks:
+            for pid in pids:
+                try:
+                    ftasks.write(pid)
+                    ftasks.flush()
+                except ProcessLookupError:
+                    log.warning('Could not write pid %s to resctrl (%r). '
+                                'Process probably does not exist. '
+                                % (pid, tasks_filepath))
+
+    def add_tasks(self, pids, mongroup_name):
+        """Adds the pids to the resctrl group and creates mongroup with the pids.
+           If the resctrl group does not exists creates it (lazy creation).
+           If already the mongroup exists just add the pids (no error will be thrown)."""
+        if not check_resctrl():
             return
 
-        attempt = 1
-        while attempt <= max_attempts:
-            tasks = ''
-            with open(os.path.join(self.cgroup_fullpath, TASKS_FILENAME)) as f:
-                tasks += f.read()
-            log.log(logger.TRACE, 'sync: Read tasks for %r (found %d pids)'
-                    % (self.resgroup_dir, len(tasks)))
-
+        # create control group directory
+        if not self.is_root_group:
             try:
-                log.log(logger.TRACE, 'resctrl: makedirs(%s)', self.resgroup_dir)
-                os.makedirs(self.resgroup_dir, exist_ok=True)
+                log.log(logger.TRACE, 'resctrl: makedirs(%s)', self.fullpath)
+                os.makedirs(self.fullpath, exist_ok=True)
             except OSError as e:
                 if e.errno == errno.ENOSPC:  # "No space left on device"
                     raise Exception("Limit of workloads reached! (Oot of available CLoSes/RMIDs!)")
                 raise
 
-            try:
-                log.log(logger.TRACE, 'sync: Writings tasks for %r' % (self.resgroup_dir))
-                with open(self.resgroup_tasks, 'w') as f:
-                    with SetEffectiveRootUid():
-                        for task in tasks.split():
-                            f.write(task)
-                            f.flush()
-            except ProcessLookupError:
-                log.warning('Could not write process pids to resctrl (%r). '
-                            'Process probably does not exist. '
-                            'Restarting synchronization (attempt=%d).'
-                            % (self.resgroup_dir, attempt))
-                attempt += 1
-                continue
+        # add pids to /tasks file
+        self._add_pids_to_tasks_file(pids, os.path.join(self.fullpath, 'tasks'))
 
-            log.log(logger.TRACE,
-                    'sync: Succesful synchronization for %r - braking' % self.resgroup_dir)
-            break
+        # create mongroup and write tasks there
+        mongroup_fullpath = self._get_mongroup_fullpath(mongroup_name)
+        os.makedirs(mongroup_fullpath, exist_ok=True)
+        self._add_pids_to_tasks_file(pids, os.path.join(mongroup_fullpath, 'tasks'))
 
-        else:
-            log.warning('sync: Unsuccessful synchronization attempts. Ignoring.')
+    def remove_tasks(self, mongroup_name):
+        """Removes the mongroup and all pids inside it from the resctrl group."""
+        if not check_resctrl():
             return
 
-        log.log(logger.TRACE,
-                'sync: Succesful synchronization for %r - returning' % self.resgroup_dir)
+        # read tasks that belongs to the mongroup
+        mongroup_fullpath = self._get_mongroup_fullpath(mongroup_name)
+        pids = self._read_pids_from_tasks_file(os.path.join(mongroup_fullpath, 'tasks'))
 
-    def get_measurements(self) -> Measurements:
+        # remove the mongroup directory
+        os.rmdir(mongroup_fullpath)
+
+        # removes tasks from the group by adding it to the root group
+        self._add_pids_to_tasks_file(pids, os.path.join(BASE_RESCTRL_PATH, 'tasks'))
+
+    def get_measurements(self, mongroup_name) -> Measurements:
         """
         mbm_total: Memory bandwidth - type: counter, unit: [bytes]
         :return: Dictionary containing memory bandwidth
@@ -165,18 +183,56 @@ class ResGroup:
         mbm_total = 0
         llc_occupancy = 0
 
+        def _get_event_file(mon_dir, event_name):
+            return os.path.join(self.fullpath, MON_DATA, mon_dir, event_name)
+
         # mon_dir contains event files for specific socket:
         # llc_occupancy, mbm_total_bytes, mbm_local_bytes
-        for mon_dir in os.listdir(os.path.join(self.resgroup_dir, MON_DATA)):
-            with open(os.path.join(self.resgroup_dir, MON_DATA,
-                                   mon_dir, MBM_TOTAL)) as mbm_total_file:
+        for mon_dir in os.listdir(os.path.join(self.fullpath, MON_GROUPS, mongroup_name, MON_DATA)):
+            with open(_get_event_file(mon_dir, MBM_TOTAL)) as mbm_total_file:
                 mbm_total += int(mbm_total_file.read())
-            with open(os.path.join(self.resgroup_dir, MON_DATA,
-                                   mon_dir, LLC_OCCUPANCY)) as llc_occupancy_file:
+            with open(_get_event_file(mon_dir, LLC_OCCUPANCY)) as llc_occupancy_file:
                 llc_occupancy += int(llc_occupancy_file.read())
 
         return {MetricName.MEM_BW: mbm_total, MetricName.LLC_OCCUPANCY: llc_occupancy}
 
+    def get_allocations(self):
+        rdt_allocations = RDTAllocation()
+        with open(os.path.join(self.fullpath, SCHEMATA)) as schemata:
+            for line in schemata:
+                if 'MB' in line:
+                    rdt_allocations.mb = line
+                elif 'L3' in line:
+                    rdt_allocations.l3 = line
+
+        return {AllocationType.RDT: rdt_allocations}
+
+    def perform_allocations(self, task_allocations):
+        with open(os.path.join(self.fullpath, SCHEMATA), 'bw') as schemata:
+            # @TODO the code below has some bug
+            # if (AllocationType.RDT in task_allocations and
+            #         task_allocations[AllocationType.RDT].mb is not None):
+            #     value = task_allocations[AllocationType.RDT].mb
+            #     log.log(logger.TRACE, 'resctrl: write(%s): %r', schemata.name, value)
+            #     try:
+            #         schemata.write(bytes(value + '\n', encoding='utf-8'))
+            #         schemata.flush()
+            #     except OSError as e:
+            #         log.error('Cannot set rdt memory bandwith allocation: {}'.format(e))
+
+            if (AllocationType.RDT in task_allocations and
+                    task_allocations[AllocationType.RDT].l3 is not None):
+                value = task_allocations[AllocationType.RDT].l3
+                log.log(logger.TRACE, 'resctrl: write(%s): %r', schemata.name, value)
+                try:
+                    schemata.write(bytes(value + '\n', encoding='utf-8'))
+                    schemata.flush()
+                except OSError as e:
+                    log.error('Cannot set l3 cache allocation: {}'.format(e))
+
     def cleanup(self):
-        log.log(logger.TRACE, 'resctrl: rmdir(%s)', self.resgroup_dir)
-        os.rmdir(self.resgroup_dir)
+        log.log(logger.TRACE, 'resctrl: rmdir(%s)', self.fullpath)
+        try:
+            os.rmdir(self.fullpath)
+        except FileNotFoundError:
+            pass

--- a/owca/runner.py
+++ b/owca/runner.py
@@ -13,56 +13,28 @@
 # limitations under the License.
 
 
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import List, Dict, Optional, Tuple
 import logging
 import time
-from typing import List, Dict, Optional
-from abc import ABC, abstractmethod
-
-from dataclasses import dataclass, field
 
 from owca import detectors, nodes
-from owca import logger
 from owca import platforms
 from owca import storage
-from owca.containers import Container
+from owca.containers import ContainerManager
 from owca.detectors import (TasksMeasurements, TasksResources,
-                            TasksLabels, convert_anomalies_to_metrics)
-from owca.mesos import MesosTask, create_metrics, sanitize_mesos_label
+                            TasksLabels, convert_anomalies_to_metrics,
+                            update_anomalies_metrics_with_task_information
+                            )
+from owca.allocators import Allocator, TasksAllocations, convert_allocations_to_metrics, \
+    AllocationConfiguration
+from owca.mesos import create_metrics, sanitize_mesos_label
 from owca.metrics import Metric, MetricType
 from owca.resctrl import check_resctrl, cleanup_resctrl
 from owca.security import are_privileges_sufficient
 
 log = logging.getLogger(__name__)
-
-
-def _calculate_desired_state(
-        discovered_tasks: List[MesosTask], known_containers: List[Container]
-) -> (List[MesosTask], List[Container]):
-    """Prepare desired state of system by comparing actual running Mesos tasks and already
-    watched containers.
-
-    Assumptions:
-    * One-to-one relationship between task and container
-    * cgroup_path for task and container need to be identical to establish the relationship
-    * cgroup_path is unique for each task
-
-    :returns "list of Mesos tasks to start watching" and "orphaned containers to cleanup" (there are
-    no more Mesos tasks matching those containers)
-    """
-    discovered_task_cgroup_paths = {task.cgroup_path for task in discovered_tasks}
-    containers_cgroup_paths = {container.cgroup_path for container in known_containers}
-
-    # Filter out containers which are still running according to Mesos agent.
-    # In other words pick orphaned containers.
-    containers_to_delete = [container for container in known_containers
-                            if container.cgroup_path not in discovered_task_cgroup_paths]
-
-    # Filter out tasks which are monitored using "Container abstraction".
-    # In other words pick new, not yet monitored tasks.
-    new_tasks = [task for task in discovered_tasks
-                 if task.cgroup_path not in containers_cgroup_paths]
-
-    return new_tasks, containers_to_delete
 
 
 class Runner(ABC):
@@ -73,8 +45,176 @@ class Runner(ABC):
         ...
 
 
+class BaseRunnerMixin:
+    """Provides common functionallity for both Allocator and Detector.
+    - configure_rdt based on self.rdt_enabled property
+    - wait_or_finish based on self.action_delay property
+    - includes container manager to sync container state
+    - metrics_storage and extra_labels for input data labeling and storing
+    """
+
+    def __init__(self, rdt_enabled: bool,
+                 allocation_configuration: Optional[AllocationConfiguration]):
+        platform_cpus, _, _ = platforms.collect_topology_information()
+        self.containers_manager = ContainerManager(
+            rdt_enabled,
+            platform_cpus=platform_cpus,
+            allocation_configuration=allocation_configuration
+        )
+
+        # statistics state
+        self.anomaly_last_occurence = None
+        self.anomaly_counter = 0
+        self.allocations_counter = 0
+
+    def configure_rdt(self, rdt_enabled, ignore_privileges_check: bool):
+        """Check required permission for using rdt and initilize subsystem.
+        Returns False, if rdt wasn't properly configured. """
+        if rdt_enabled and not check_resctrl():
+            return False
+        elif not rdt_enabled:
+            log.warning('Rdt disabled. Skipping collecting measurements '
+                        'and resctrl synchronization')
+        else:
+            # Resctrl is enabled and available - cleanup previous runs.
+            cleanup_resctrl()
+
+        if ignore_privileges_check:
+            return True
+
+        if not are_privileges_sufficient():
+            log.critical("Impossible to use perf_event_open. You need to: adjust "
+                         "/proc/sys/kernel/perf_event_paranoid; or has CAP_DAC_OVERRIDE capability"
+                         " set. You can run process as root too. See man 2 perf_event_open for "
+                         "details.")
+            return False
+
+        return True
+
+    def wait_or_finish(self, delay):
+        """Decides how long one run takes and when to finish.
+        TODO: handle graceful shutdown on signal
+        """
+        time.sleep(delay)
+        return True
+
+    def _prepare_tasks_data(self, containers) -> Tuple[
+            List[Metric], TasksMeasurements, TasksResources, TasksLabels, TasksAllocations]:
+        """Build labeled tasks_metrics and task_metrics_values."""
+        tasks_measurements: TasksMeasurements = {}
+        tasks_resources: TasksResources = {}
+        tasks_labels: TasksLabels = {}
+        tasks_metrics: List[Metric] = []
+        tasks_allocations: TasksAllocations = {}
+        for task, container in containers.items():
+            # Single task data
+            task_measurements = container.get_measurements()
+            task_metrics = create_metrics(task_measurements)
+            # Prepare tasks labels based on Mesos tasks metadata labels and task id.
+            task_labels = {
+                sanitize_mesos_label(label_key): label_value
+                for label_key, label_value
+                in task.labels.items()
+            }
+            task_labels['task_id'] = task.task_id
+
+            task_allocations = container.get_allocations()
+
+            # Task scoped label decoration.
+            for task_metric in task_metrics:
+                task_metric.labels.update(task_labels)
+
+            # Aggregate over all tasks.
+            tasks_labels[task.task_id] = task_labels
+            tasks_measurements[task.task_id] = task_measurements
+            tasks_resources[task.task_id] = task.resources
+            tasks_metrics += task_metrics
+            tasks_allocations[task.task_id] = task_allocations
+
+        return tasks_metrics, tasks_measurements, tasks_resources, tasks_labels, tasks_allocations
+
+    def get_internal_metrics(self, tasks):
+        """Internal owca metrics."""
+        return [
+            Metric(name='owca_up', type=MetricType.COUNTER, value=time.time()),
+            Metric(name='owca_tasks', type=MetricType.GAUGE, value=len(tasks)),
+        ]
+
+    def get_anomalies_statistics_metrics(self, anomalies, detect_duration=None):
+        """Extra external plugin anomaly & allocaton statistics."""
+        if len(anomalies):
+            self.anomaly_last_occurence = time.time()
+            self.anomaly_counter += len(anomalies)
+
+        statistics_metrics = [
+            Metric(name='anomaly_count', type=MetricType.COUNTER, value=self.anomaly_counter),
+        ]
+        if self.anomaly_last_occurence:
+            statistics_metrics.extend([
+                Metric(name='anomaly_last_occurence', type=MetricType.COUNTER,
+                       value=self.anomaly_last_occurence),
+            ])
+        if detect_duration is not None:
+            statistics_metrics.extend([
+                Metric(name='detect_duration', type=MetricType.GAUGE, value=detect_duration)
+            ])
+        return statistics_metrics
+
+    def get_allocations_statistics_metrics(self, allocations, allocation_duration=None):
+        """Extra external plugin anomaly & allocaton statistics."""
+        if len(allocations):
+            self.allocations_counter += len(allocations)
+
+        statistics_metrics = [
+            Metric(name='allocations_count', type=MetricType.COUNTER,
+                   value=self.allocations_counter),
+        ]
+
+        if allocation_duration is not None:
+            statistics_metrics.extend([
+                Metric(name='allocation_duration', type=MetricType.GAUGE,
+                       value=allocation_duration)
+            ])
+
+        return statistics_metrics
+
+    def _prepare_input_and_send_metrics_package(self, node: nodes.Node,
+                                                metrics_storage: storage.Storage,
+                                                extra_labels: Dict[str, str]) -> \
+            Tuple[platforms.Platform, TasksMeasurements, TasksResources, TasksLabels,
+                  TasksAllocations, Dict[str, str]]:
+
+        # Collect information about tasks running on node.
+        tasks = node.get_tasks()
+
+        # Keep sync of found tasks and internally managed containers.
+        containers = self.containers_manager.sync_containers_state(tasks)
+
+        metrics_package = MetricPackage(metrics_storage)
+        metrics_package.add_metrics(self.get_internal_metrics(tasks))
+
+        # Platform information
+        platform, platform_metrics, platform_labels = platforms.collect_platform_information()
+        metrics_package.add_metrics(platform_metrics)
+
+        # Common labels
+        common_labels = dict(platform_labels, **extra_labels)
+
+        # Tasks informations
+        (tasks_metrics, tasks_measurements, tasks_resources, tasks_labels, tasks_allocations
+         ) = self._prepare_tasks_data(containers)
+        metrics_package.add_metrics(tasks_metrics)
+        metrics_package.send(common_labels)
+
+        return (platform, tasks_measurements, tasks_resources,
+                tasks_labels, tasks_allocations, common_labels)
+
+    def cleanup(self):
+        self.containers_manager.cleanup()
+
+
 @dataclass
-class DetectionRunner(Runner):
+class DetectionRunner(Runner, BaseRunnerMixin):
     """Watch over tasks running on this cluster on this node, collect observation
     and report externally (using storage) detected anomalies.
     """
@@ -85,168 +225,129 @@ class DetectionRunner(Runner):
     action_delay: float = 0.  # [s]
     rdt_enabled: bool = True
     extra_labels: Dict[str, str] = field(default_factory=dict)
+    ignore_privileges_check: bool = False
 
     def __post_init__(self):
-        self.containers: Dict[MesosTask, Container] = {}
-        self.anomaly_counter: int = 0
-        self.anomaly_last_occurence: Optional[int] = None
+        BaseRunnerMixin.__init__(self, self.rdt_enabled, None)
 
-    def wait_or_finish(self):
-        """Decides how long one run takes and when to finish.
-        TODO: handle graceful shutdown on signal
-        """
-        time.sleep(self.action_delay)
-        return True
-
-    def _sync_containers_state(self, tasks):
-        """Sync internal state of runner by removing orphaned containers, and creating containers
-        for newly arrived tasks, and synchronizing containers' state.
-
-        Function is responsible for cleaning or initializing measurements stateful subsystems
-        and their external resources, e.g.:
-        - perf counters opens file descriptors for counters,
-        - resctrl (ResGroups) creates and manages directories under resctrl fs and scarce "clsid"
-            hardware identifiers
-
-        """
-        # Find difference between discovered Mesos tasks and already watched containers.
-        new_tasks, containers_to_cleanup = _calculate_desired_state(
-            tasks, list(self.containers.values()))
-
-        if containers_to_cleanup:
-            log.debug('state: cleaning up %d containers', len(containers_to_cleanup))
-            log.log(logger.TRACE, 'state: containers_to_cleanup=%r', containers_to_cleanup)
-
-        # Cleanup and remove orphaned containers (cleanup).
-        for container_to_cleanup in containers_to_cleanup:
-            container_to_cleanup.cleanup()
-        self.containers = {task: container
-                           for task, container in self.containers.items()
-                           if task in tasks}
-
-        if new_tasks:
-            log.debug('state: found %d new tasks', len(new_tasks))
-            log.log(logger.TRACE, 'state: new_tasks=%r', new_tasks)
-
-        # Create new containers and store them.
-        for new_task in new_tasks:
-            self.containers[new_task] = Container(new_task.cgroup_path,
-                                                  rdt_enabled=self.rdt_enabled)
-
-        # Sync state of individual containers.
-        for container in self.containers.values():
-            container.sync()
-
-    @logger.trace(log)
     def run(self):
-        if self.rdt_enabled and not check_resctrl():
-            return
-        elif not self.rdt_enabled:
-            log.warning('Rdt disabled. Skipping collecting measurements '
-                        'and resctrl synchronization')
-        else:
-            # Resctrl is enabled and available - cleanup previous runs.
-            cleanup_resctrl()
-
-        if not are_privileges_sufficient():
-            log.critical("Impossible to use perf_event_open. You need to: adjust "
-                         "/proc/sys/kernel/perf_event_paranoid; or has CAP_DAC_OVERRIDE capability"
-                         " set. You can run process as root too. See man 2 perf_event_open for "
-                         "details.")
+        if not self.configure_rdt(self.rdt_enabled, self.ignore_privileges_check):
             return
 
         while True:
-            # Collect information about tasks running on node.
-            tasks = self.node.get_tasks()
+            # Prepare input and send input based metrics.
+            platform, tasks_measurements, \
+                tasks_resources, tasks_labels, tasks_allocations, common_labels = \
+                self._prepare_input_and_send_metrics_package(
+                    self.node, self.metrics_storage, self.extra_labels)
 
-            # Keep sync of found tasks and internally managed containers.
-            self._sync_containers_state(tasks)
-
-            # Owca internal metrics.
-            internal_metrics = [
-                Metric(name='owca_up', type=MetricType.COUNTER, value=time.time()),
-                Metric(name='owca_tasks', type=MetricType.GAUGE, value=len(tasks)),
-            ]
-
-            # Platform information
-            platform, platform_metrics, platform_labels = platforms.collect_platform_information()
-
-            # Common labels
-            common_labels = dict(platform_labels, **self.extra_labels)
-
-            # Update platform_metrics with common labels.
-            for metric in platform_metrics + internal_metrics:
-                metric.labels.update(common_labels)
-
-            # Build labeled tasks_metrics and task_metrics_values.
-            tasks_measurements: TasksMeasurements = {}
-            tasks_resources: TasksResources = {}
-            tasks_labels: TasksLabels = {}
-            tasks_metrics: List[Metric] = []
-            for task, container in self.containers.items():
-                # Single task data
-                task_measurements = container.get_measurements()
-                task_metrics = create_metrics(task_measurements)
-                # Prepare tasks labels based on Mesos tasks metadata labels and task id.
-                task_labels = {
-                    sanitize_mesos_label(label_key): label_value
-                    for label_key, label_value
-                    in task.labels.items()
-                }
-                task_labels['task_id'] = task.task_id
-
-                # Task scoped label decoration.
-                for task_metric in task_metrics:
-                    task_metric.labels.update(common_labels)
-                    task_metric.labels.update(task_labels)
-
-                # Aggregate over all tasks.
-                tasks_labels[task.task_id] = task_labels
-                tasks_measurements[task.task_id] = task_measurements
-                tasks_resources[task.task_id] = task.resources
-                tasks_metrics += task_metrics
-
-            self.metrics_storage.store(platform_metrics + tasks_metrics + internal_metrics)
-
+            # Detector callback
+            detect_start = time.time()
             anomalies, extra_metrics = self.detector.detect(
                 platform, tasks_measurements, tasks_resources, tasks_labels)
+            detect_duration = time.time() - detect_start
+            log.debug('Anomalies detected (in %.2fs): %d', detect_duration, len(anomalies))
+
+            # Prepare anomly metrics
+            anomaly_metrics = convert_anomalies_to_metrics(anomalies)
+            update_anomalies_metrics_with_task_information(anomaly_metrics, tasks_labels)
+
+            # Prepare and send all output (anomalies) metrics.
+            anomalies_package = MetricPackage(self.anomalies_storage)
+            anomalies_package.add_metrics(
+                anomaly_metrics,
+                extra_metrics,
+                self.get_anomalies_statistics_metrics(anomalies, detect_duration)
+            )
+            anomalies_package.send(common_labels)
+
+            if not self.wait_or_finish(self.action_delay):
+                break
+
+        self.cleanup()
+
+
+class MetricPackage:
+    """Wraps storage to pack metrics from diffrent sources and apply common labels
+    before send."""
+    def __init__(self, storage: storage.Storage):
+        self.storage = storage
+        self.metrics: List[Metric] = []
+
+    def add_metrics(self, *metrics_args: List[Metric]):
+        for metrics in metrics_args:
+            self.metrics.extend(metrics)
+
+    def send(self, common_labels: Dict[str, str] = None):
+        """Apply common_labels and send using storage from constructor. """
+        if common_labels:
+            for metric in self.metrics:
+                metric.labels.update(common_labels)
+        self.storage.store(self.metrics)
+
+
+@dataclass
+class AllocationRunner(Runner, BaseRunnerMixin):
+
+    node: nodes.Node
+    allocator: Allocator
+    metrics_storage: storage.Storage
+    anomalies_storage: storage.Storage
+    allocations_storage: storage.Storage
+    action_delay: float = 1.  # [s]
+    rdt_enabled: bool = True
+    extra_labels: Dict[str, str] = field(default_factory=dict)
+    ignore_privileges_check: bool = False
+    allocation_configuration: Optional[AllocationConfiguration] = None
+
+    def __post_init__(self):
+        BaseRunnerMixin.__init__(self, self.rdt_enabled, self.allocation_configuration)
+
+    def run(self):
+        if not self.configure_rdt(self.rdt_enabled, self.ignore_privileges_check):
+            return
+
+        while True:
+            # Prepare input and send input based metrics.
+            platform, tasks_measurements, tasks_resources, \
+                tasks_labels, tasks_allocations, common_labels = \
+                self._prepare_input_and_send_metrics_package(
+                    self.node, self.metrics_storage, self.extra_labels)
+
+            # Allocator callback
+            allocate_start = time.time()
+            new_tasks_allocations, anomalies, extra_metrics = self.allocator.allocate(
+                platform, tasks_measurements, tasks_resources, tasks_labels, tasks_allocations)
+            allocate_duration = time.time() - allocate_start
 
             log.debug('Anomalies detected: %d', len(anomalies))
+            log.debug('Allocations received: %d', len(new_tasks_allocations))
+
+            all_allocations = self.containers_manager.sync_allocations(
+                old_allocations=tasks_allocations,
+                new_allocations=new_tasks_allocations
+            )
 
             # Note: anomaly metrics include metrics found in ContentionAnomaly.metrics.
             anomaly_metrics = convert_anomalies_to_metrics(anomalies)
+            update_anomalies_metrics_with_task_information(anomaly_metrics, tasks_labels)
 
-            for anomaly_metric in anomaly_metrics:
-                # Extra labels for anomaly metrics for information about task.
-                if 'contended_task_id' in anomaly_metric.labels:  # Only for anomaly metrics.
-                    contended_task_id = anomaly_metric.labels['contended_task_id']
-                    anomaly_metric.labels.update(
-                        tasks_labels.get(contended_task_id, {})
-                    )
+            anomalies_package = MetricPackage(self.anomalies_storage)
+            anomalies_package.add_metrics(self.get_anomalies_statistics_metrics(anomalies))
+            anomalies_package.add_metrics(extra_metrics)
+            anomalies_package.send(common_labels)
 
-            # Extra anomaly statistics
-            if len(anomalies):
-                self.anomaly_last_occurence = time.time()
-                self.anomaly_counter += len(anomalies)
+            # Store allocations information
+            allocations_metrics = convert_allocations_to_metrics(all_allocations)
+            allocations_package = MetricPackage(self.allocations_storage)
+            allocations_package.add_metrics(
+                allocations_metrics,
+                extra_metrics,
+                self.get_allocations_statistics_metrics(new_tasks_allocations, allocate_duration),
+            )
+            allocations_package.send(common_labels)
 
-            statistics_metrics = [
-                Metric(name='anomaly_count', type=MetricType.COUNTER, value=self.anomaly_counter),
-            ]
-            if self.anomaly_last_occurence:
-                statistics_metrics.extend([
-                    Metric(name='anomaly_last_occurence', type=MetricType.COUNTER,
-                           value=self.anomaly_last_occurence),
-                ])
-
-            # Update anomaly & extra metrics with common labels.
-            for metric in anomaly_metrics + extra_metrics + statistics_metrics:
-                metric.labels.update(common_labels)
-
-            self.anomalies_storage.store(anomaly_metrics + extra_metrics + statistics_metrics)
-
-            if not self.wait_or_finish():
+            if not self.wait_or_finish(self.action_delay):
                 break
 
-        # cleanup
-        for container in self.containers.values():
-            container.cleanup()
+        self.cleanup()

--- a/owca/testing.py
+++ b/owca/testing.py
@@ -38,7 +38,9 @@ def create_open_mock(sys_file_mock):
         def __call__(self, path, mode='rb'):
             mock_data = self.file_sys[path]
             if isinstance(mock_data, str):
-                return StringIO(mock_data)
+                s = StringIO(mock_data)
+                s.name = path  # Behave like a file with name.
+                return s
             else:
                 return mock_data(path, mode)
 

--- a/tests/test_allocations.py
+++ b/tests/test_allocations.py
@@ -1,0 +1,76 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from owca.allocators import _calculate_task_allocations, _calculate_tasks_allocations, \
+    RDTAllocation, AllocationType
+
+r = AllocationType.RDT
+
+
+@pytest.mark.parametrize(
+    'old_task_allocations,new_task_allocations,'
+    'expected_all_task_allocations,expected_resulting_task_allocations', (
+        ({}, {},
+         {}, {}),
+        ({'a': 0.2}, {},
+         {'a': 0.2}, {}),
+        ({'b': 2}, {'b': 3},
+         {'b': 3}, {'b': 3}),
+        ({'a': 0.2, 'b': 0.4}, {'b': 0.5},
+         {'a': 0.2, 'b': 0.5}, {'b': 0.5}),
+        ({}, {'a': 0.2, 'b': 0.5},
+         {'a': 0.2, 'b': 0.5}, {'a': 0.2, 'b': 0.5}),
+        # RDTAllocations
+        ({}, {r: RDTAllocation(name='', l3='ff')},
+         {r: RDTAllocation(name='', l3='ff')}, {r: RDTAllocation(name='', l3='ff')}),
+        ({r: RDTAllocation(name='', l3='ff')}, {},
+         {r: RDTAllocation(name='', l3='ff')}, {}),
+        ({r: RDTAllocation(name='', l3='ff')}, {r: RDTAllocation(name='x', l3='ff')},
+         {r: RDTAllocation(name='x', l3='ff')}, {r: RDTAllocation(name='x', l3='ff')}),
+        ({r: RDTAllocation(name='x', l3='ff')}, {r: RDTAllocation(name='x', l3='dd')},
+         {r: RDTAllocation(name='x', l3='dd')}, {r: RDTAllocation(name='x', l3='dd')}),
+        ({r: RDTAllocation(name='x', l3='dd', mb='ff')}, {r: RDTAllocation(name='x', mb='ff')},
+         {r: RDTAllocation(name='x', l3='dd', mb='ff')}, {r: RDTAllocation(name='x', mb='ff')}),
+    ))
+def test_calculate_task_allocations(
+        old_task_allocations, new_task_allocations,
+        expected_all_task_allocations, expected_resulting_task_allocations):
+    all_task_allocations, resulting_task_allocations = _calculate_task_allocations(
+        old_task_allocations, new_task_allocations
+    )
+    assert all_task_allocations == expected_all_task_allocations
+    assert resulting_task_allocations == expected_resulting_task_allocations
+
+
+@pytest.mark.parametrize(
+    'old_tasks_allocations,new_tasks_allocations,'
+    'expected_all_tasks_allocations,expected_resulting_tasks_allocations', (
+        ({}, {},
+         {}, {}),
+        (dict(t1={'a': 2}), {},
+         dict(t1={'a': 2}), {}),
+        (dict(t1={'a': 1}), dict(t1={'b': 2}, t2={'b': 3}),
+         dict(t1={'a': 1, 'b': 2}, t2={'b': 3}), dict(t1={'b': 2}, t2={'b': 3})),
+    ))
+def test_calculate_tasks_allocations(
+        old_tasks_allocations, new_tasks_allocations,
+        expected_all_tasks_allocations, expected_resulting_tasks_allocations
+):
+    all_tasks_allocations, resulting_tasks_allocations = _calculate_tasks_allocations(
+        old_tasks_allocations, new_tasks_allocations
+    )
+    assert all_tasks_allocations == expected_all_tasks_allocations
+    assert resulting_tasks_allocations == expected_resulting_tasks_allocations

--- a/tests/test_cgroups.py
+++ b/tests/test_cgroups.py
@@ -12,16 +12,62 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest.mock import patch, mock_open, MagicMock, call
 
-from owca.cgroups import Cgroup
-
-from unittest.mock import patch, mock_open
+import pytest
 
 from owca.metrics import MetricName
+from owca.allocators import AllocationConfiguration
+from owca.cgroups import Cgroup
+from owca.testing import create_open_mock
 
 
 @patch('builtins.open', mock_open(read_data='100'))
 def test_get_measurements():
-    cgroup = Cgroup('/some/foo1')
+    cgroup = Cgroup('/some/foo1', platform_cpus=1)
     measurements = cgroup.get_measurements()
     assert measurements == {MetricName.CPU_USAGE_PER_TASK: 100}
+
+
+@patch('builtins.open', mock_open(read_data='100'))
+def test_cgroup_read():
+    cgroup = Cgroup('/some/foo1', platform_cpus=1)
+    value = cgroup._read('some_ctr_file')
+    assert value == 100
+
+
+def test_cgroup_write():
+    cgroup = Cgroup('/some/foo1', platform_cpus=1)
+    ctrl_file_mock = MagicMock()
+    full_path = '/sys/fs/cgroup/cpu/some/foo1/some_ctrl_file'
+    open_mock = create_open_mock({full_path: ctrl_file_mock})
+    with patch('builtins.open', open_mock):
+        cgroup._write('some_ctrl_file', 5)
+    ctrl_file_mock.assert_called_once_with(full_path, 'wb')
+    ctrl_file_mock.assert_has_calls([call().__enter__().write(b'5')])
+
+
+@patch('owca.containers.Cgroup._read', return_value=1000)
+def test_get_normalized_shares(_read_mock):
+    cgroup = Cgroup('/some/foo1', platform_cpus=1,
+                    allocation_configuration=AllocationConfiguration())
+    assert cgroup._get_normalized_shares() == pytest.approx(0.1, 0.01)
+
+
+@patch('builtins.open', create_open_mock({
+    '/sys/fs/cgroup/cpu/some/foo1/cpu.cfs_period_us': '100000',
+    '/sys/fs/cgroup/cpu/some/foo1/cpu.cfs_quota_us': '-1',
+}))
+def test_get_normalized_quota():
+    cgroup = Cgroup('/some/foo1', platform_cpus=1,
+                    allocation_configuration=AllocationConfiguration())
+    assert cgroup._get_normalized_quota() == float('inf')
+
+
+@patch('builtins.open', create_open_mock({
+    '/sys/fs/cgroup/cpu/some/foo1/tasks': '101\n102',
+    '/sys/fs/cgroup/cpu/foo2/tasks': '',
+}))
+def test_cgroup_get_tasks():
+    assert Cgroup('/some/foo1', platform_cpus=1).get_tasks() == [101, 102]
+    assert Cgroup('/foo2', platform_cpus=1).get_tasks() == []

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -1,0 +1,113 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import patch, Mock
+
+import pytest
+
+from owca.containers import Container, _calculate_desired_state
+from owca.metrics import Metric
+from owca.runner import DetectionRunner
+from owca.testing import task
+
+
+def container(cgroup_path):
+    """Helper method to create container with patched subsystems."""
+    with patch('owca.containers.ResGroup'), patch('owca.containers.PerfCounters'):
+        return Container(cgroup_path, rdt_enabled=False, platform_cpus=1)
+
+
+def metric(name, labels=None):
+    """Helper method to create metric with default values. Value is ignored during tests."""
+    return Metric(name=name, value=1234, labels=labels or {})
+
+
+@pytest.mark.parametrize(
+    'discovered_tasks,containers,expected_new_tasks,expected_containers_to_delete', (
+        # scenario when two task are created and them first one is removed,
+        ([task('/t1')], [],  # one new task, just arrived
+         [task('/t1')], []),  # should created one container
+        ([task('/t1')], [container('/t1')],  # after one iteration, our state is converged
+         [], []),  # no actions
+        ([task('/t1'), task('/t2')], [container('/t1'), ],  # another task arrived,
+         [task('/t2')], []),  # let's create another container,
+        ([task('/t1'), task('/t2')], [container('/t1'), container('/t2')],  # 2on2 converged
+         [], []),  # nothing to do,
+        ([task('/t2')], [container('/t1'), container('/t2')],  # first task just disappeared
+         [], [container('/t1')]),  # remove the first container
+        # some other cases
+        ([task('/t1'), task('/t2')], [],  # the new task, just appeared
+         [task('/t1'), task('/t2')], []),
+        ([task('/t1'), task('/t3')], [container('/t1'),
+                                      container('/t2')],  # t2 replaced with t3
+         [task('/t3')], [container('/t2')]),  # nothing to do,
+    ))
+def test_calculate_desired_state(
+        discovered_tasks,
+        containers,
+        expected_new_tasks,
+        expected_containers_to_delete):
+
+    new_tasks, containers_to_delete = _calculate_desired_state(
+        discovered_tasks, containers
+    )
+
+    assert new_tasks == expected_new_tasks
+    assert containers_to_delete == expected_containers_to_delete
+
+
+@patch('owca.containers.ResGroup')
+@patch('owca.containers.PerfCounters')
+@patch('owca.containers.Container.sync')
+@patch('owca.containers.Container.cleanup')
+@patch('owca.platforms.collect_topology_information', return_value=(1, 1, 1))
+@pytest.mark.parametrize('tasks,existing_containers,expected_running_containers', (
+    ([], {},
+     {}),
+    ([task('/t1')], {},
+     {task('/t1'): container('/t1')}),
+    ([task('/t1')], {task('/t2'): container('/t2')},
+     {task('/t1'): container('/t1')}),
+    ([task('/t1')], {task('/t1'): container('/t1'), task('/t2'): container('/t2')},
+     {task('/t1'): container('/t1')}),
+    ([], {task('/t1'): container('/t1'), task('/t2'): container('/t2')},
+     {}),
+))
+def test_sync_containers_state(platform_mock, cleanup_mock, sync_mock,
+                               PerfCoutners_mock, ResGroup_mock,
+                               tasks, existing_containers,
+                               expected_running_containers):
+
+    # Mocker runner, because we're only interested in one sync_containers_state function.
+    runner = DetectionRunner(
+        node=Mock(),
+        metrics_storage=Mock(),
+        anomalies_storage=Mock(),
+        detector=Mock(),
+        rdt_enabled=False,
+    )
+    # Prepare internal state used by sync_containers_state function - mock.
+    # Use list for copying to have original list.
+    runner.containers_manager.containers = dict(existing_containers)
+
+    # Call it.
+    got_containers = runner.containers_manager.sync_containers_state(tasks)
+
+    # Check internal state ...
+    assert expected_running_containers == got_containers
+
+    # Check other side effects like calling sync() on external objects.
+    assert sync_mock.call_count == len(expected_running_containers)
+    number_of_removed_containers = len(set(existing_containers) - set(expected_running_containers))
+    assert cleanup_mock.call_count == number_of_removed_containers

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -19,9 +19,11 @@ from owca.mesos import MesosTask
 from owca.logger import init_logging
 from owca.testing import create_open_mock
 
+import pytest
 
 yaml_config = '''
 runner: !DetectionRunner
+  ignore_privileges_check: true
   node: !MesosNode
   action_delay: 1.
   metrics_storage: !LogStorage
@@ -107,13 +109,15 @@ mesos_tasks_mocks = [
 ]
 
 
+@pytest.mark.skip('WIP')
 @mock.patch('sys.argv', ['owca', '-c', 'configs/see_yaml_config_variable_above.yaml',
-                         '-r', 'example.external_package:ExampleDetector', '-l', 'trace'])
+                         '-r', 'example.external_package:ExampleDetector', '-l', 'trace',
+                         '--root'])
 @mock.patch('os.rmdir')
 @mock.patch('owca.config.exists', return_value=True)
 @mock.patch('owca.config.open', mock.mock_open(read_data=yaml_config))
 @mock.patch('owca.mesos.MesosNode.get_tasks', return_value=mesos_tasks_mocks)
-@mock.patch('owca.resctrl.ResGroup.sync')
+@mock.patch('owca.resctrl.ResGroup.add_tasks')
 @mock.patch('owca.containers.PerfCounters')
 @mock.patch('owca.runner.DetectionRunner.wait_or_finish', return_value=False)
 @mock.patch('builtins.open', new=create_open_mock({

--- a/tests/test_resctrl.py
+++ b/tests/test_resctrl.py
@@ -31,6 +31,7 @@ def test_check_resctrl(*mock):
     assert check_resctrl()
 
 
+@pytest.mark.skip('work in progress')
 @patch('owca.resctrl.log.warning')
 @patch('os.path.exists', return_value=True)
 @patch('os.makedirs')
@@ -61,6 +62,7 @@ def test_sync(*args):
         resctrl_file_mock_complex_name.assert_has_calls([call().__enter__().write('123')])
 
 
+@pytest.mark.skip('work in progress')
 @patch('owca.resctrl.log.warning')
 @patch('os.path.exists', return_value=True)
 @patch('os.makedirs', side_effect=OSError(errno.ENOSPC, "mock"))
@@ -73,6 +75,7 @@ def test_sync_no_space_left_on_device(makedirs_mock, exists_mock, log_warning_mo
         resgroup.sync()
 
 
+@pytest.mark.skip('work in progress')
 @patch('owca.resctrl.log.warning')
 @patch('os.path.exists', return_value=False)
 def test_sync_resctrl_not_mounted(exists_mock, log_warning_mock):
@@ -82,6 +85,7 @@ def test_sync_resctrl_not_mounted(exists_mock, log_warning_mock):
     log_warning_mock.assert_called_once_with('Resctrl not mounted, ignore sync!')
 
 
+@pytest.mark.skip('work in progress')
 @patch('owca.resctrl.log.warning')
 @patch('os.path.exists', return_value=True)
 @patch('os.makedirs')
@@ -111,6 +115,7 @@ def test_sync_flush_exception(SetEffectiveRootUid_mock, makedirs_mock,
         log_warning_mock.assert_any_call('sync: Unsuccessful synchronization attempts. Ignoring.')
 
 
+@pytest.mark.skip('work in progress')
 @patch('builtins.open', new=create_open_mock({
     "/sys/fs/resctrl/mon_groups/ddd/mon_data/1/mbm_total_bytes": "1",
     "/sys/fs/resctrl/mon_groups/ddd/mon_data/2/mbm_total_bytes": "1",
@@ -125,6 +130,7 @@ def test_get_measurements(*mock):
     assert {'memory_bandwidth': 2, 'llc_occupancy': 2} == resgroup.get_measurements()
 
 
+@pytest.mark.skip('work in progress')
 @patch('builtins.open', new=create_open_mock({
     "/sys/fs/resctrl/mesos-1/tasks": "1\n2\n",
     "/sys/fs/resctrl/mesos-2/tasks": "",  # resctrl group to recycle - expected to be removed.

--- a/tests/test_runner.py
+++ b/tests/test_runner.py
@@ -13,105 +13,16 @@
 # limitations under the License.
 
 
-import pytest
 from unittest.mock import patch, Mock
 
-from owca.runner import _calculate_desired_state, DetectionRunner
+from owca.runner import DetectionRunner
 from owca.mesos import MesosNode, sanitize_mesos_label
-from owca.containers import Container
 from owca import storage
 from owca import platforms
 from owca.metrics import Metric, MetricType
 from owca.detectors import AnomalyDetector
 from owca.testing import anomaly_metrics, anomaly, task
-
-
-def container(cgroup_path):
-    """Helper method to create container with patched subsystems."""
-    with patch('owca.containers.ResGroup'), patch('owca.containers.PerfCounters'):
-        return Container(cgroup_path, rdt_enabled=False)
-
-
-def metric(name, labels=None):
-    """Helper method to create metric with default values. Value is ignored during tests."""
-    return Metric(name=name, value=1234, labels=labels or {})
-
-
-@pytest.mark.parametrize(
-    'discovered_tasks,containers,expected_new_tasks,expected_containers_to_delete', (
-        # scenario when two task are created and them first one is removed,
-        ([task('/t1')], [],  # one new task, just arrived
-         [task('/t1')], []),  # should created one container
-        ([task('/t1')], [container('/t1')],  # after one iteration, our state is converged
-         [], []),  # no actions
-        ([task('/t1'), task('/t2')], [container('/t1'), ],  # another task arrived,
-         [task('/t2')], []),  # let's create another container,
-        ([task('/t1'), task('/t2')], [container('/t1'), container('/t2')],  # 2on2 converged
-         [], []),  # nothing to do,
-        ([task('/t2')], [container('/t1'), container('/t2')],  # first task just disappeared
-         [], [container('/t1')]),  # remove the first container
-        # some other cases
-        ([task('/t1'), task('/t2')], [],  # the new task, just appeared
-         [task('/t1'), task('/t2')], []),
-        ([task('/t1'), task('/t3')], [container('/t1'),
-                                      container('/t2')],  # t2 replaced with t3
-         [task('/t3')], [container('/t2')]),  # nothing to do,
-    ))
-def test_calculate_desired_state(
-        discovered_tasks,
-        containers,
-        expected_new_tasks,
-        expected_containers_to_delete):
-
-    new_tasks, containers_to_delete = _calculate_desired_state(
-        discovered_tasks, containers
-    )
-
-    assert new_tasks == expected_new_tasks
-    assert containers_to_delete == expected_containers_to_delete
-
-
-@patch('owca.containers.ResGroup')
-@patch('owca.containers.PerfCounters')
-@patch('owca.containers.Container.sync')
-@patch('owca.containers.Container.cleanup')
-@pytest.mark.parametrize('tasks,existing_containers,expected_running_containers', (
-    ([], {},
-     {}),
-    ([task('/t1')], {},
-     {task('/t1'): container('/t1')}),
-    ([task('/t1')], {task('/t2'): container('/t2')},
-     {task('/t1'): container('/t1')}),
-    ([task('/t1')], {task('/t1'): container('/t1'), task('/t2'): container('/t2')},
-     {task('/t1'): container('/t1')}),
-    ([], {task('/t1'): container('/t1'), task('/t2'): container('/t2')},
-     {}),
-))
-def test_sync_containers_state(cleanup_mock, sync_mock, PerfCoutners_mock, ResGroup_mock,
-                               tasks, existing_containers,
-                               expected_running_containers):
-
-    # Mocker runner, because we're only interested in one sync_containers_state function.
-    runner = DetectionRunner(
-        node=Mock(),
-        metrics_storage=Mock(),
-        anomalies_storage=Mock(),
-        detector=Mock(),
-        rdt_enabled=False,
-    )
-    # Prepare internal state used by sync_containers_state function.
-    runner.containers = dict(existing_containers)  # Use list for copying to have original list.
-
-    # Call it.
-    runner._sync_containers_state(tasks)
-
-    # Check internal state ...
-    assert expected_running_containers == runner.containers
-
-    # Check other side effects like calling sync() on external objects.
-    assert sync_mock.call_count == len(expected_running_containers)
-    number_of_removed_containers = len(set(existing_containers) - set(expected_running_containers))
-    assert cleanup_mock.call_count == number_of_removed_containers
+from tests.test_containers import container, metric
 
 
 # We are mocking objects used by containers.
@@ -120,6 +31,7 @@ def test_sync_containers_state(cleanup_mock, sync_mock, PerfCoutners_mock, ResGr
 @patch('owca.runner.are_privileges_sufficient', return_value=True)
 @patch('owca.containers.ResGroup')
 @patch('owca.containers.PerfCounters')
+@patch('owca.platforms.collect_topology_information', return_value=(1, 1, 1))
 @patch('owca.containers.Cgroup.get_measurements', return_value=dict(cpu_usage=23))
 @patch('time.time', return_value=1234567890.123)
 def test_runner_containers_state(*mocks):
@@ -188,11 +100,11 @@ def test_runner_containers_state(*mocks):
     # store() method was called twice:
     # 1. Before calling detect() to store state of the environment.
     metrics_storage.store.assert_called_once_with([
-             metric('platform-cpu-usage', labels=extra_labels),  # Store metrics from platform ...
-             Metric(name='cpu_usage', value=23,
-                    labels=dict(extra_labels, **task_labels_sanitized_with_task_id)),
-             Metric('owca_up', type=MetricType.COUNTER, value=1234567890.123, labels=extra_labels),
-             Metric('owca_tasks', type=MetricType.GAUGE, value=1, labels=extra_labels),
+        Metric('owca_up', type=MetricType.COUNTER, value=1234567890.123, labels=extra_labels),
+        Metric('owca_tasks', type=MetricType.GAUGE, value=1, labels=extra_labels),
+        metric('platform-cpu-usage', labels=extra_labels),  # Store metrics from platform ...
+        Metric(name='cpu_usage', value=23,
+               labels=dict(extra_labels, **task_labels_sanitized_with_task_id)),
     ])  # and task
 
     # 2. After calling detect to store information about detected anomalies.
@@ -207,6 +119,7 @@ def test_runner_containers_state(*mocks):
         Metric('anomaly_count', type=MetricType.COUNTER, value=1, labels=extra_labels),
         Metric('anomaly_last_occurence', type=MetricType.COUNTER, value=1234567890.123,
                labels=extra_labels),
+        Metric(name='detect_duration', value=0.0, labels={'el': 'ev'}, type=MetricType.GAUGE),
     ])
     anomalies_storage.store.assert_called_once_with(expected_anomaly_metrics)
 
@@ -219,7 +132,7 @@ def test_runner_containers_state(*mocks):
     )
 
     # assert expected state (new container based on first task /t1)
-    assert (runner.containers ==
+    assert (runner.containers_manager.containers ==
             {task('/t1', resources=dict(cpus=8.), labels=task_labels): container('/t1')})
 
     runner.wait_or_finish.assert_called_once()

--- a/workloads/run_workloads.yaml
+++ b/workloads/run_workloads.yaml
@@ -356,3 +356,20 @@
       tags: tensorflow_benchmark_prediction
       command: "{{create_job_command}}"
       loop: "{{instances_version_iterator}}"
+
+    - name: Create stress_ng workload
+      vars:
+        workload_name: stress_ng
+        job_uniq_id: "{{item.workload_instance_index}}"
+        load_generator: stress_ng
+        application: stress_ng
+        job_id: stress_ng
+        job_name: "{{job_id}}.{{workload_version_name}}--{{job_uniq_id}}"
+        own_ip: "{{application_host_ip}}"
+        communication_port: 0
+        resources: "{{workload_version.resources | default(default_resources)}}"
+      environment: "{{workload_version.env | default({}) }}"
+      delegate_to: localhost
+      tags: stress_ng
+      command: "{{create_job_command}}"
+      loop: "{{instances_version_iterator}}"

--- a/workloads/run_workloads_inventory.template.yaml
+++ b/workloads/run_workloads_inventory.template.yaml
@@ -173,3 +173,11 @@ application_hosts:
             cpu: 10
             ram: 50
             disk: 30
+
+      stress_ng:
+        default:
+          count: 1
+          resources:
+            cpu: 1
+            ram: 1
+            disk: 1

--- a/workloads/stress_ng/stress_ng.aurora
+++ b/workloads/stress_ng/stress_ng.aurora
@@ -1,0 +1,43 @@
+# Copyright (c) 2018 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+import os
+
+include('../common.aurora')
+
+#----------------------------------------------------------------------------------------------------
+###
+# Params which can be modified by exporting environment variables.
+###
+
+# Port that stressed application listens on.
+stress_ng_params = os.environ.get('stress_ng_params', '--stream 1')
+#----------------------------------------------------------------------------------------------------
+
+
+jobs = [
+    WorkloadService(
+        task=SequentialTask(
+            name=job_name,
+            resources=Resources(cpu=cpu, ram=ram, disk=disk),
+            processes=[
+                Process(
+                    name='redis',
+                    cmdline='stress-ng %s' % stress_ng_params
+                ),
+            ],
+        ),
+    ),
+]


### PR DESCRIPTION
Allocation API implementation:

Not fully working yet.
Contains work from PR: https://github.com/intel/owca/pull/10

Should be removed from this PR:
* stress_ng workload 

Changes:
- major refactor of runners, extracting common functionality
- implementing functionality of assigning multiple tasks to the same resgroup

TODO:
- [x] refactor runners to extract common functinoallity
- [x] RDT resources allocation
- [x] RDT independed monitoring and allocations (MON_GROUPS cs CTRL_GROUPS)
- [x] cgroup based resources allocation
- [x] extra profiling metrics
- [x] refactor labelling (as metrics package)
- [x] calculating resulting allocations
- [ ] encoding allocations as metrics
- [ ] unit tests:
  - [x] Cgroup object
  - [x] ResGroup object
  - [x] resulting allocations 
  - [ ] AllocationRunner
- [in-progress] functional/e2e tests on dedicated hardware
- [ ] documentation (another PR)
- [x] simple allocator example
