### PR TITLE
Replace improper Task abstract class with dataclass

### DIFF
--- a/owca/detectors.py
+++ b/owca/detectors.py
@@ -21,7 +21,7 @@ from enum import Enum
 from typing import List, Dict
 
 from owca.metrics import Metric, Measurements, MetricType
-from owca.mesos import TaskId
+from owca.nodes import TaskId
 from owca.platforms import Platform
 
 

--- a/owca/mesos.py
+++ b/owca/mesos.py
@@ -13,18 +13,16 @@
 # limitations under the License.
 
 
-from dataclasses import dataclass, field
-from typing import Dict, List, Union
-import urllib.parse
 import logging
 import os
+import urllib.parse
+from typing import List, Union
 
 import requests
+from dataclasses import dataclass
 
-# Mesos tasks id
-from owca.nodes import Node, TaskId
 from owca.metrics import Measurements, Metric
-
+from owca.nodes import Node, Task
 
 MESOS_TASK_STATE_RUNNING = 'TASK_RUNNING'
 CGROUP_DEFAULT_SUBSYSTEM = 'cpu'
@@ -33,30 +31,18 @@ log = logging.getLogger(__name__)
 
 
 @dataclass
-class MesosTask:  # implements nodes.Task but abstractclasses cannot be implemented by dataclasses
+class MesosTask(Task):
 
-    name: str
-
+    # Fields only used debugging purposes.
     executor_pid: int
     container_id: str  # Mesos containerizer identifier "ID used to uniquely identify a container"
-    task_id: TaskId  # Mesos-level task identifier
-
-    # for debugging purposes
     executor_id: str
     agent_id: str
 
-    # inferred
-    cgroup_path: str  # Starts with leading "/"
-    labels: Dict[str, str] = field(default_factory=dict)
-
-    # Resources assigned accorind Mesos/Aurora task definition.
-    resources: Dict[str, float] = field(default_factory=dict)
-
     def __hash__(self):
-        """Every instance of mesos task is uniqully identified by cgroup_path.
-        Assumption here is that every mesos task is represented by one main cgroup.
+        """Reuse __hash__ method from base class, because dataclasses by default
         """
-        return id(self.cgroup_path)
+        return super().__hash__()
 
 
 def find_cgroup(pid):
@@ -75,7 +61,6 @@ def find_cgroup(pid):
 
 @dataclass
 class MesosNode(Node):
-
     mesos_agent_endpoint: str = 'https://127.0.0.1:5051'
     ssl_verify: Union[bool, str] = True  # requests: Can be used to pass cert CA bundle.
 

--- a/owca/mesos.py
+++ b/owca/mesos.py
@@ -40,7 +40,9 @@ class MesosTask(Task):
     agent_id: str
 
     def __hash__(self):
-        """Reuse __hash__ method from base class, because dataclasses by default
+        """Override __hash__ method from base class and call it explicitly to workaround
+        __hash__ methods overriding by dataclasses (dataclass rules specify if eq is True and
+        there is no explict __hash__ method - replace it with None dataclasses.py:739).
         """
         return super().__hash__()
 

--- a/owca/nodes.py
+++ b/owca/nodes.py
@@ -13,35 +13,34 @@
 # limitations under the License.
 
 
-from abc import ABC, abstractproperty, abstractmethod
+from abc import ABC, abstractmethod
 from typing import List, Dict
+
+from dataclasses import dataclass
 
 TaskId = str
 
 
-class Task(ABC):
-    """Base task container based class."""
+@dataclass
+class Task:
+    # Human-friendly name of task
+    name: str
 
-    @abstractproperty
-    def name(self) -> str:
-        """Human-friendly name of task."""
+    # Orchestration-level task identifier
+    task_id: TaskId
 
-    @abstractproperty
-    def task_id(self) -> TaskId:
-        """Orchestration-level task identifier."""
+    # Path to cgroup that all processes reside in. Starts with leading "/".
+    cgroup_path: str
 
-    @abstractproperty
-    def cgroup_path(self) -> str:
-        """Path to cgroup that all processes reside in.
-           Starts with leading "/"."""
+    # Task metadata expressed as labels.
+    labels: Dict[str, str]
 
-    @abstractproperty
-    def labels(self) -> Dict[str, str]:
-        """Task metadata expressed as labels."""
+    # Initial resources assigned at orchestation level.
+    resources: Dict[str, str]
 
-    @abstractproperty
-    def resources(self) -> Dict[str, str]:
-        """Initial resources assigned accorind task definition. """
+    def __hash__(self):
+        """Every instance of task is uniqully identified by cgroup_path."""
+        return hash(self.cgroup_path)
 
 
 class Node(ABC):

--- a/owca/nodes.py
+++ b/owca/nodes.py
@@ -35,11 +35,11 @@ class Task:
     # Task metadata expressed as labels.
     labels: Dict[str, str]
 
-    # Initial resources assigned at orchestation level.
+    # Initial resources assigned at orchestration level.
     resources: Dict[str, str]
 
     def __hash__(self):
-        """Every instance of task is uniqully identified by cgroup_path."""
+        """Every instance of task is uniquely identified by cgroup_path."""
         return hash(self.cgroup_path)
 
 

--- a/owca/runner.py
+++ b/owca/runner.py
@@ -27,8 +27,9 @@ from owca import storage
 from owca.containers import Container
 from owca.detectors import (TasksMeasurements, TasksResources,
                             TasksLabels, convert_anomalies_to_metrics)
-from owca.mesos import MesosTask, create_metrics, sanitize_mesos_label
+from owca.mesos import create_metrics, sanitize_mesos_label
 from owca.metrics import Metric, MetricType
+from owca.nodes import Task
 from owca.resctrl import check_resctrl, cleanup_resctrl
 from owca.security import are_privileges_sufficient
 
@@ -36,8 +37,8 @@ log = logging.getLogger(__name__)
 
 
 def _calculate_desired_state(
-        discovered_tasks: List[MesosTask], known_containers: List[Container]
-) -> (List[MesosTask], List[Container]):
+        discovered_tasks: List[Task], known_containers: List[Container]
+) -> (List[Task], List[Container]):
     """Prepare desired state of system by comparing actual running Mesos tasks and already
     watched containers.
 
@@ -87,7 +88,7 @@ class DetectionRunner(Runner):
     extra_labels: Dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self):
-        self.containers: Dict[MesosTask, Container] = {}
+        self.containers: Dict[Task, Container] = {}
         self.anomaly_counter: int = 0
         self.anomaly_last_occurence: Optional[int] = None
 

--- a/owca/testing.py
+++ b/owca/testing.py
@@ -20,7 +20,7 @@ from typing import List, Dict, Union
 from unittest.mock import mock_open, Mock
 
 from owca.detectors import ContendedResource, ContentionAnomaly, _create_uuid_from_tasks_ids
-from owca.mesos import MesosTask, TaskId
+from owca.nodes import TaskId, Task
 from owca.metrics import Metric, MetricType
 
 
@@ -98,14 +98,10 @@ def anomaly(contended_task_id: TaskId, contending_task_ids: List[TaskId],
 
 def task(cgroup_path, labels=None, resources=None):
     """Helper method to create task with default values."""
-    return MesosTask(
+    return Task(
         cgroup_path=cgroup_path,
         name='name-' + cgroup_path,
-        executor_pid=1,
-        container_id='container_id-' + cgroup_path,
         task_id='task-id-' + cgroup_path,
-        executor_id='executor-id-' + cgroup_path,
-        agent_id='agent-id-' + cgroup_path,
         labels=labels or dict(),
         resources=resources or dict()
     )

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -103,6 +103,8 @@ mesos_tasks_mocks = [
         agent_id='some_mesos_agent_id',
         executor_id='some_mesos_executor_id',
         cgroup_path='/mesos/xxxx-yyy',
+        labels=dict(),
+        resources=dict()
     )
 ]
 

--- a/tests/test_mesos.py
+++ b/tests/test_mesos.py
@@ -32,10 +32,13 @@ def create_json_fixture_mock(name, status_code=200):
 @patch('owca.mesos.find_cgroup', return_value='mesos/120-123')
 def test_get_tasks(find_cgroup_mock, post_mock):
     node = MesosNode()
-    tasks = node.get_tasks()
+    tasks = set(node.get_tasks())  # Wrap with set to make sure that hash is implemented.
     assert len(tasks) == 1
 
-    task = tasks[0]
+    task = tasks.pop()
+
+
+
     assert task == MesosTask(
         agent_id='e88fac89-2398-4e75-93f3-88cf4c35ec03-S9',
         cgroup_path='mesos/120-123',

--- a/tests/test_mesos.py
+++ b/tests/test_mesos.py
@@ -14,8 +14,9 @@
 
 
 import json
-import pytest
 from unittest.mock import patch, Mock
+
+import pytest
 
 from owca.mesos import MesosNode, MesosTask
 from owca.testing import relative_module_path
@@ -36,8 +37,6 @@ def test_get_tasks(find_cgroup_mock, post_mock):
     assert len(tasks) == 1
 
     task = tasks.pop()
-
-
 
     assert task == MesosTask(
         agent_id='e88fac89-2398-4e75-93f3-88cf4c35ec03-S9',


### PR DESCRIPTION
Rationale:
- **abstractproperty** were used improperly 
- **abstractproperty** can only enforce method based "property" not the normal one, that is way **MesosTask** couldn't properly iherit from it

Now Task dataclass is enough and Node implementation have no create owns Task implementation and can just reuse existing dataclass.

Quirks:
- in MesosTask we still have to create __hash__ classes because how dataclass treat __hash__ method ([here is explanation](https://github.com/python/cpython/blob/3.7/Lib/dataclasses.py#L118))
- base Task class cannot have default properties (e.g. labels or resources) - because then all inherited class need to have all fields optional (check [this ](https://stackoverflow.com/questions/51575931/class-inheritance-in-python-3-7-dataclasses)fur further discussion)