### PR TITLE
Check metrics exists in list of metrics include labels submatch tooling.

### DIFF
--- a/owca/testing.py
+++ b/owca/testing.py
@@ -16,7 +16,7 @@
 """Module for independent simple helper functions."""
 
 import os
-from typing import List, Dict, Union
+from typing import List, Dict, Union, Optional
 from unittest.mock import mock_open, Mock
 
 from owca.detectors import ContendedResource, ContentionAnomaly, _create_uuid_from_tasks_ids
@@ -109,3 +109,58 @@ def task(cgroup_path, labels=None, resources=None):
         labels=labels or dict(),
         resources=resources or dict()
     )
+
+ 
+def assert_subdict(got_dict: dict, expected_subdict: dict):
+    """Assert that one dict is a subset of another dict in recursive manner.
+    """
+    for expected_key, expected_value in expected_subdict.items():
+        if expected_key not in got_dict:
+            raise AssertionError('key %r no found in %r' % (expected_key, got_dict))
+        got_value = got_dict[expected_key]
+        if isinstance(expected_value, dict):
+            # for dict use subsets
+            if isinstance(got_value, dict):
+                raise AssertionError('expected dict type at %r key, got %r' % (
+                    expected_key, type(got_value)))
+            assert_subdict(got_value, expected_value)
+        else:
+            # for other types check ordinary equality operator
+            assert got_value == expected_value
+
+
+def _is_dict_match(got_dict: dict, expected_subdict: dict):
+    """Match values and keys from dict (non recursive)."""
+    for expected_key, expected_value in expected_subdict.items():
+        if expected_key not in got_dict:
+            return False
+        else:
+            if got_dict[expected_key] != expected_value:
+                return False
+    return True
+
+
+def assert_metric(got_metrics: List[Metric],
+                  expected_metric_name: str,
+                  expected_metric_some_labels: Optional[Dict] = None,
+                  expected_metric_value: Optional[Union[float, int]] = None,
+                  ):
+    """Assert that given metrics exists in given set of metrics."""
+    found_metric = None
+    for got_metric in got_metrics:
+        if got_metric.name == expected_metric_name:
+            # found by name, should we check labels ?
+            if expected_metric_some_labels is not None:
+                # yes check by labels
+                if _is_dict_match(got_metric.labels, expected_metric_some_labels):
+                    found_metric = got_metric
+                    break
+            else:
+                found_metric = got_metric
+                break
+    if not found_metric:
+        raise AssertionError('metric %r not found' % expected_metric_name)
+    # Check values as well
+    if expected_metric_value is not None:
+        assert found_metric.value == expected_metric_value, 'metric value differs'
+

--- a/owca/testing.py
+++ b/owca/testing.py
@@ -113,19 +113,21 @@ def task(cgroup_path, labels=None, resources=None):
 
 def assert_subdict(got_dict: dict, expected_subdict: dict):
     """Assert that one dict is a subset of another dict in recursive manner.
+    Check if expected key exists and if value matches expected value.
     """
     for expected_key, expected_value in expected_subdict.items():
         if expected_key not in got_dict:
             raise AssertionError('key %r not found in %r' % (expected_key, got_dict))
         got_value = got_dict[expected_key]
         if isinstance(expected_value, dict):
-            # for dict use subsets
+            # When comparing with dict use 'containment' operation instead of equal.
+            # If expected value is a dict, call assert_subdict recursively.
             if not isinstance(got_value, dict):
                 raise AssertionError('expected dict type at %r key, got %r' % (
                     expected_key, type(got_value)))
             assert_subdict(got_value, expected_value)
         else:
-            # for other types check ordinary equality operator
+            # For any other type check using ordinary equality operator.
             assert got_value == expected_value, \
                 'value differs got=%r expected=%r at key=%r' % (
                     got_value, expected_value, expected_key)
@@ -136,9 +138,8 @@ def _is_dict_match(got_dict: dict, expected_subdict: dict):
     for expected_key, expected_value in expected_subdict.items():
         if expected_key not in got_dict:
             return False
-        else:
-            if got_dict[expected_key] != expected_value:
-                return False
+        if got_dict[expected_key] != expected_value:
+            return False
     return True
 
 
@@ -164,4 +165,6 @@ def assert_metric(got_metrics: List[Metric],
         raise AssertionError('metric %r not found' % expected_metric_name)
     # Check values as well
     if expected_metric_value is not None:
-        assert found_metric.value == expected_metric_value, 'metric value differs'
+        assert found_metric.value == expected_metric_value, \
+            'metric name=%r value differs got=%r expected=%r' % (
+                found_metric.name, found_metric.value, expected_metric_value)

--- a/owca/testing.py
+++ b/owca/testing.py
@@ -110,23 +110,25 @@ def task(cgroup_path, labels=None, resources=None):
         resources=resources or dict()
     )
 
- 
+
 def assert_subdict(got_dict: dict, expected_subdict: dict):
     """Assert that one dict is a subset of another dict in recursive manner.
     """
     for expected_key, expected_value in expected_subdict.items():
         if expected_key not in got_dict:
-            raise AssertionError('key %r no found in %r' % (expected_key, got_dict))
+            raise AssertionError('key %r not found in %r' % (expected_key, got_dict))
         got_value = got_dict[expected_key]
         if isinstance(expected_value, dict):
             # for dict use subsets
-            if isinstance(got_value, dict):
+            if not isinstance(got_value, dict):
                 raise AssertionError('expected dict type at %r key, got %r' % (
                     expected_key, type(got_value)))
             assert_subdict(got_value, expected_value)
         else:
             # for other types check ordinary equality operator
-            assert got_value == expected_value
+            assert got_value == expected_value, \
+                'value differs got=%r expected=%r at key=%r' % (
+                    got_value, expected_value, expected_key)
 
 
 def _is_dict_match(got_dict: dict, expected_subdict: dict):
@@ -163,4 +165,3 @@ def assert_metric(got_metrics: List[Metric],
     # Check values as well
     if expected_metric_value is not None:
         assert found_metric.value == expected_metric_value, 'metric value differs'
-

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,5 +1,21 @@
+# Copyright (c) 2019 Intel Corporation
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 from unittest.mock import patch, call, mock_open
-from owca.testing import create_open_mock
+from owca.testing import create_open_mock, _is_dict_match, assert_metric
+from owca.metrics import Metric
+import pytest
 
 
 def test_create_open_mock_autocreated():
@@ -21,3 +37,42 @@ def test_create_open_mock_manually():
         open('/some/path.txt', 'w').write('bar')
         my_own_mock_open.assert_has_calls(
             [call().write('bar')])
+
+
+@pytest.mark.parametrize('got_dict, expected_subdict, expected_match', [
+    (dict(), dict(), True),  # Empty query always match
+    (dict(x=1), dict(), True),  # ditto,
+    (dict(), dict(x=1), False),  # Non empty query doesn't match empty dict,
+    (dict(x=2), dict(x=1), False),  # no when value is different
+    (dict(x=1), dict(x=1), True),  # ok for the same
+    (dict(x=1, y=2), dict(x=1), True),  # additional parameters doesn't interfere
+    (dict(x=1, y=2), dict(x=1, y=2), True),  # two params exact match
+    (dict(x=1, y=1, z=3), dict(x=1, y=2), False),  # two keys mismatch
+    (dict(x=1, y=2, z=3), dict(x=1, y=2), True),  # two vs three keys match
+])
+def test_match_keys(got_dict, expected_subdict, expected_match):
+    assert _is_dict_match(got_dict, expected_subdict) == expected_match
+
+
+@pytest.mark.parametrize(
+    'got_metrics, expected_metric_name, '
+    'expected_metric_labels, expected_metric_value, exception_message', [
+        ([Metric('foo', 2)], 'foo', None, None, None),
+        ([Metric('foo', 2)], 'foo', None, 2, None),
+        ([Metric('foo', 2)], 'foo', None, 3, 'metric value differs'),
+        ([Metric('foo', 2)], 'foo', dict(), 2, None),
+        ([Metric('foo', 2, labels=dict(a='b'))], 'foo', None, 3, 'metric value differs'),
+        ([Metric('foo', 2, labels=dict(a='b'))], 'foo', None, 2, None),
+        ([Metric('foo', 2, labels=dict(a='b'))], 'foo', dict(), 2, None),
+        ([Metric('foo', 2, labels=dict(a='b'))], 'foo', dict(a='b'), 2, None),
+        ([Metric('foo', 2, labels=dict(a='b'))], 'foo', dict(a='c'), 2, 'not found'),
+    ])
+def test_assert_metric(got_metrics, expected_metric_name,
+                       expected_metric_labels, expected_metric_value, exception_message):
+    if exception_message is not None:
+        with pytest.raises(AssertionError, match=exception_message):
+            assert_metric(got_metrics, expected_metric_name,
+                          expected_metric_labels, expected_metric_value)
+    else:
+        assert_metric(got_metrics, expected_metric_name,
+                      expected_metric_labels, expected_metric_value)


### PR DESCRIPTION
two functions:
- `assert_metric` - metrics with matching labels existing in given list and value optionally equals (used for testing for some metrics in `storage.store` calls)
- `assert_subdict` - on dict is a subdict of another in recursive manner (used for testing that `detect`/`allocate` got right data