### PR TITLE
Configurable perf events (support for raw and predefined dervied events)

### DIFF
--- a/configs/extra/static_measurements_with_extra_metrics.yaml
+++ b/configs/extra/static_measurements_with_extra_metrics.yaml
@@ -4,6 +4,7 @@ runner: !MeasurementRunner
     - cycles
     - cache_references
     - cache_misses
+    - instructionraw_rC000
   enable_derived_metrics: true
   node: !StaticNode
     tasks:

--- a/configs/extra/static_measurements_with_extra_metrics.yaml
+++ b/configs/extra/static_measurements_with_extra_metrics.yaml
@@ -1,0 +1,10 @@
+runner: !MeasurementRunner
+  event_names:
+    - instructions
+    - cycles
+    - cache_references
+    - cache_misses
+  enable_derived_metrics: true
+  node: !StaticNode
+    tasks:
+      - task1

--- a/configs/extra/static_measurements_with_extra_metrics.yaml
+++ b/configs/extra/static_measurements_with_extra_metrics.yaml
@@ -4,7 +4,7 @@ runner: !MeasurementRunner
     - cycles
     - cache_references
     - cache_misses
-    - instructionraw_rC000
+    - instructionraw__rC000
   enable_derived_metrics: true
   node: !StaticNode
     tasks:

--- a/docs/allocation.rst
+++ b/docs/allocation.rst
@@ -66,6 +66,10 @@ corresponding storage classes.
                 (defaults to AllocationConfiguration() instance)
             remove_all_resctrl_groups (bool): remove all RDT controls groups upon starting
                 (defaults to False)
+            event_names: perf counters to monitor
+                (defaults to instructions, cycles, cache-misses, memstalls)
+            enable_derived_metrics: enable derived metrics ips, ipc and cache_hit_ratio
+                (based on enabled_event names), default to False
         """
 
         def __init__(
@@ -81,6 +85,8 @@ corresponding storage classes.
                 extra_labels: Dict[str, str] = None,
                 allocation_configuration: Optional[AllocationConfiguration] = None,
                 remove_all_resctrl_groups: bool = False,
+                event_names: Optional[List[str]] = None,
+                enable_derived_metrics: bool = False,
         ):
         ...
 

--- a/owca/extra/static_node.py
+++ b/owca/extra/static_node.py
@@ -38,6 +38,7 @@ class StaticNode(Node):
 
     # List of task names.
     tasks: List[str]
+    require_pids: bool = False
 
     _BASE_CGROUP_PATH = '/sys/fs/cgroup'
     _REQUIRED_CONTROLLERS = ('cpu', 'cpuacct', 'perf_event')
@@ -47,9 +48,13 @@ class StaticNode(Node):
         for task_name in self.tasks:
             for required_controller in self._REQUIRED_CONTROLLERS:
                 full_cgroup_path = os.path.join(
-                    self._BASE_CGROUP_PATH, required_controller, task_name)
+                    self._BASE_CGROUP_PATH, required_controller, task_name, 'tasks')
                 if not os.path.exists(full_cgroup_path):
                     log.warning('StaticNode: There is no required cgroup %r for %r - skipping!',
+                                full_cgroup_path, task_name)
+                    break
+                if self.require_pids and len(open(full_cgroup_path).readlines()) == 0:
+                    log.warning('StaticNode: There is no pids in cgroup %r for %r - skipping!',
                                 full_cgroup_path, task_name)
                     break
             else:

--- a/owca/metrics.py
+++ b/owca/metrics.py
@@ -23,6 +23,7 @@ class MetricName(str, Enum):
     INSTRUCTIONS = 'instructions'
     CYCLES = 'cycles'
     CACHE_MISSES = 'cache_misses'
+    CACHE_REFERENCES = 'cache_references'
     CPU_USAGE_PER_CPU = 'cpu_usage_per_cpu'
     CPU_USAGE_PER_TASK = 'cpu_usage_per_task'
     MEM_BW = 'memory_bandwidth'

--- a/owca/perf.py
+++ b/owca/perf.py
@@ -171,12 +171,12 @@ def _create_event_attributes(event_name, disabled):
     elif event_name in pc.HardwareEventNameMap:
         attr.type = pc.PerfType.PERF_TYPE_HARDWARE
         attr.config = pc.HardwareEventNameMap[event_name]
-    else:
-        # raw event  with the format: name_rEEUUCC,
+    elif '__r' in event_name:
+        # raw event  with the format: name__rEEUUCC,
         # where UU == umask, and EE == event number and optionally CMASK
         # parsed as hex
-        assert '_r' in event_name
-        _, hexs = event_name.split('_r')
+        # TODO: better validation
+        _, hexs = event_name.split('__r')
         event = int(hexs[0:2], 16)
         umask = int(hexs[2:4], 16)
         if len(hexs) == 6:
@@ -186,6 +186,8 @@ def _create_event_attributes(event_name, disabled):
 
         attr.type = pc.PerfType.PERF_TYPE_RAW
         attr.config = event | (umask << 8) | (cmask << 24)
+    else:
+        raise Exception('unknown event name %r' % event_name)
 
     log.log(logger.TRACE,
             'perf: event_attribute: name=%r type=%r config=%r',

--- a/owca/perf.py
+++ b/owca/perf.py
@@ -212,11 +212,13 @@ class DerivedMetricsGenerator:
         # if specific pairs are available calculate derived metrics
         if self._prev_measurements is not None:
             if metrics_available(MetricName.INSTRUCTIONS, MetricName.CYCLES):
-                inst_delta, cycles_delta = delta(MetricName.INSTRUCTIONS, MetricName.CYCLES)
+                inst_delta, cycles_delta = delta(MetricName.INSTRUCTIONS,
+                                                 MetricName.CYCLES)
                 measurements['ipc'] = float(inst_delta) / cycles_delta
-            if metrics_available(MetricName.INSTRUCTIONS, MetricName.CYCLES):
-                inst_delta, cycles_delta = delta(MetricName.INSTRUCTIONS, MetricName.CYCLES)
-                measurements['cache_misses_ratio'] = float(inst_delta) / cycles_delta
+            if metrics_available(MetricName.CACHE_REFERENCES, MetricName.CACHE_MISSES):
+                cache_ref_delta, cache_misses_delta = delta(MetricName.CACHE_REFERENCES,
+                                                            MetricName.CACHE_MISSES)
+                measurements['cache_misses_ratio'] = float(cache_ref_delta) / cache_misses_delta
 
         self._prev_measurements = measurements
 

--- a/owca/perf.py
+++ b/owca/perf.py
@@ -175,15 +175,17 @@ def _parse_raw_event_name(event_name: str) -> int:
         raise Exception('raw events name is expected to contain "__r" characters.')
     try:
         _, bits = event_name.split('__r')
-        event = int(bits[0:2], 16)
-        umask = int(bits[2:4], 16)
         if len(bits) == 6:
             cmask = int(bits[4:6], 16)
-        else:
+        elif len(bits) == 4:
             cmask = 0
+        else:
+            raise Exception('improper raw event_name specification (length should be 4 or 6)')
+        event = int(bits[0:2], 16)
+        umask = int(bits[2:4], 16)
         return event | (umask << 8) | (cmask << 24)
     except ValueError as e:
-        raise Exception('Cannot parse raw event definition: %r' % bits) from e
+        raise Exception('Cannot parse raw event definition: %r: error %s' % (bits, e)) from e
 
 
 def _create_event_attributes(event_name, disabled):

--- a/owca/perf.py
+++ b/owca/perf.py
@@ -214,11 +214,13 @@ class DerivedMetricsGenerator:
             if metrics_available(MetricName.INSTRUCTIONS, MetricName.CYCLES):
                 inst_delta, cycles_delta = delta(MetricName.INSTRUCTIONS,
                                                  MetricName.CYCLES)
-                measurements['ipc'] = float(inst_delta) / cycles_delta
+                if cycles_delta > 0:
+                    measurements['ipc'] = float(inst_delta) / cycles_delta
             if metrics_available(MetricName.CACHE_REFERENCES, MetricName.CACHE_MISSES):
                 cache_ref_delta, cache_misses_delta = delta(MetricName.CACHE_REFERENCES,
                                                             MetricName.CACHE_MISSES)
-                measurements['cache_misses_ratio'] = float(cache_ref_delta) / cache_misses_delta
+                if cache_ref_delta > 0:
+                    measurements['cache_misses_ratio'] = float(cache_misses_delta) / cache_ref_delta
 
         self._prev_measurements = measurements
 

--- a/owca/perf_const.py
+++ b/owca/perf_const.py
@@ -99,6 +99,7 @@ HardwareEventNameMap = {
     MetricName.CYCLES: EventTypeConfig.PERF_COUNT_HW_CPU_CYCLES,
     MetricName.INSTRUCTIONS: EventTypeConfig.PERF_COUNT_HW_INSTRUCTIONS,
     MetricName.CACHE_MISSES: EventTypeConfig.PERF_COUNT_HW_CACHE_MISSES,
+    MetricName.CACHE_REFERENCES: EventTypeConfig.PERF_COUNT_HW_CACHE_REFERENCES,
 }
 
 

--- a/owca/runners/allocation.py
+++ b/owca/runners/allocation.py
@@ -178,6 +178,8 @@ class AllocationRunner(MeasurementRunner):
             (defaults to False)
         event_names: perf counters to monitor
             (defaults to instructions, cycles, cache-misses, memstalls)
+        enable_derived_metrics: enable derived metrics ips, ipc and cache_hit_ratio
+            (based on enabled_event names), default to False
     """
 
     def __init__(
@@ -194,13 +196,14 @@ class AllocationRunner(MeasurementRunner):
             allocation_configuration: Optional[AllocationConfiguration] = None,
             remove_all_resctrl_groups: bool = False,
             event_names: Optional[List[str]] = None,
+            enable_derived_metrics: bool = False,
     ):
 
         self._allocation_configuration = allocation_configuration or AllocationConfiguration()
 
         super().__init__(node, metrics_storage, action_delay, rdt_enabled,
                          extra_labels, _allocation_configuration=self._allocation_configuration,
-                         event_names=event_names)
+                         event_names=event_names, enable_derived_metrics=enable_derived_metrics)
 
         # Allocation specific.
         self._allocator = allocator

--- a/owca/runners/allocation.py
+++ b/owca/runners/allocation.py
@@ -176,6 +176,8 @@ class AllocationRunner(MeasurementRunner):
             (defaults to AllocationConfiguration() instance)
         remove_all_resctrl_groups (bool): remove all RDT controls groups upon starting
             (defaults to False)
+        event_names: perf counters to monitor
+            (defaults to instructions, cycles, cache-misses, memstalls)
     """
 
     def __init__(
@@ -191,12 +193,14 @@ class AllocationRunner(MeasurementRunner):
             extra_labels: Dict[str, str] = None,
             allocation_configuration: Optional[AllocationConfiguration] = None,
             remove_all_resctrl_groups: bool = False,
+            event_names: Optional[List[str]] = None,
     ):
 
         self._allocation_configuration = allocation_configuration or AllocationConfiguration()
 
         super().__init__(node, metrics_storage, action_delay, rdt_enabled,
-                         extra_labels, _allocation_configuration=self._allocation_configuration)
+                         extra_labels, _allocation_configuration=self._allocation_configuration,
+                         event_names=event_names)
 
         # Allocation specific.
         self._allocator = allocator

--- a/owca/runners/detection.py
+++ b/owca/runners/detection.py
@@ -65,6 +65,8 @@ class DetectionRunner(MeasurementRunner):
             (defaults to None(auto) based on platform capabilities)
         extra_labels: additional labels attached to every metric
             (defaults to empty dict)
+        event_names: perf counters to monitor
+            (defaults to instructions, cycles, cache-misses, memstalls)
     """
 
     def __init__(
@@ -76,10 +78,11 @@ class DetectionRunner(MeasurementRunner):
             action_delay: float = 1.,
             rdt_enabled: Optional[bool] = None,
             extra_labels: Dict[str, str] = None,
+            event_names: Optional[List[str]] = None,
     ):
         super().__init__(node, metrics_storage,
                          action_delay, rdt_enabled,
-                         extra_labels)
+                         extra_labels, event_names)
         self._detector = detector
 
         # Anomaly.

--- a/owca/runners/detection.py
+++ b/owca/runners/detection.py
@@ -67,6 +67,8 @@ class DetectionRunner(MeasurementRunner):
             (defaults to empty dict)
         event_names: perf counters to monitor
             (defaults to instructions, cycles, cache-misses, memstalls)
+        enable_derived_metrics: enable derived metrics ips, ipc and cache_hit_ratio
+            (based on enabled_event names), default to False
     """
 
     def __init__(
@@ -79,10 +81,12 @@ class DetectionRunner(MeasurementRunner):
             rdt_enabled: Optional[bool] = None,
             extra_labels: Dict[str, str] = None,
             event_names: Optional[List[str]] = None,
+            enable_derived_metrics: bool = False,
     ):
         super().__init__(node, metrics_storage,
                          action_delay, rdt_enabled,
-                         extra_labels, event_names)
+                         extra_labels, event_names,
+                         enable_derived_metrics)
         self._detector = detector
 
         # Anomaly.

--- a/owca/runners/measurement.py
+++ b/owca/runners/measurement.py
@@ -35,7 +35,7 @@ log = logging.getLogger(__name__)
 _INITIALIZE_FAILURE_ERROR_CODE = 1
 
 DEFAULT_EVENTS = (MetricName.INSTRUCTIONS, MetricName.CYCLES,
-                  MetricName.CACHE_MISSES, MetricName.MEMSTALL)
+                  MetricName.CACHE_MISSES, MetricName.CACHE_REFERENCES, MetricName.MEMSTALL)
 
 
 class MeasurementRunner(Runner):

--- a/owca/runners/measurement.py
+++ b/owca/runners/measurement.py
@@ -54,6 +54,8 @@ class MeasurementRunner(Runner):
             (defaults to empty dict)
         event_names: perf counters to monitor
             (defaults to instructions, cycles, cache-misses, memstalls)
+        enable_derived_metrics: enable derived metrics ips, ipc and cache_hit_ratio
+            (based on enabled_event names), default to False
     """
 
     def __init__(
@@ -64,6 +66,7 @@ class MeasurementRunner(Runner):
             rdt_enabled: Optional[bool] = None,  # Defaults(None) - auto configuration.
             extra_labels: Dict[str, str] = None,
             event_names: List[str] = None,
+            enable_derived_metrics: bool = False,
             _allocation_configuration: Optional[AllocationConfiguration] = None,
     ):
 
@@ -77,6 +80,7 @@ class MeasurementRunner(Runner):
         self._last_iteration = time.time()  # Used internally by wait function.
         self._allocation_configuration = _allocation_configuration
         self._event_names = event_names or DEFAULT_EVENTS
+        self._enable_derived_metrics = enable_derived_metrics
 
     @profiler.profile_duration(name='sleep')
     def _wait(self):
@@ -124,6 +128,7 @@ class MeasurementRunner(Runner):
             platform_cpus=platform_cpus,
             allocation_configuration=self._allocation_configuration,
             event_names=self._event_names,
+            enable_derived_metrics=self._enable_derived_metrics,
         )
         return None
 

--- a/owca/testing.py
+++ b/owca/testing.py
@@ -22,6 +22,7 @@ from unittest.mock import mock_open, Mock, patch
 
 from owca import platforms
 from owca.allocators import AllocationConfiguration
+from owca.runners.measurement import DEFAULT_EVENTS
 from owca.containers import Container, ContainerSet, ContainerInterface
 from owca.detectors import ContendedResource, ContentionAnomaly, LABEL_WORKLOAD_INSTANCE, \
     _create_uuid_from_tasks_ids
@@ -145,14 +146,18 @@ def container(cgroup_path, subcgroups_paths=None, with_config=False, should_patc
                 platform_cpus=1,
                 allocation_configuration=AllocationConfiguration() if with_config else None,
                 resgroup=ResGroup(name=resgroup_name) if rdt_enabled else None,
-                rdt_enabled=rdt_enabled, rdt_mb_control_enabled=rdt_mb_control_enabled)
+                rdt_enabled=rdt_enabled, rdt_mb_control_enabled=rdt_mb_control_enabled,
+                event_names=DEFAULT_EVENTS
+            )
         else:
             return Container(
                 cgroup_path=cgroup_path,
                 rdt_enabled=rdt_enabled, platform_cpus=1,
                 rdt_mb_control_enabled=True,
                 allocation_configuration=AllocationConfiguration() if with_config else None,
-                resgroup=ResGroup(name=resgroup_name) if rdt_enabled else None)
+                resgroup=ResGroup(name=resgroup_name) if rdt_enabled else None,
+                event_names=DEFAULT_EVENTS
+            )
 
     if should_patch:
         with patch('owca.resctrl.ResGroup'), patch('owca.perf.PerfCounters'):

--- a/tests/extra/test_static_node.py
+++ b/tests/extra/test_static_node.py
@@ -34,8 +34,9 @@ def test_static_node_without_cgroups():
     static_node = StaticNode(tasks=['task1'])
     assert static_node.get_tasks() == []
 
+
 @patch('os.path.exists', Mock(return_value=True))
 @patch('builtins.open', mock_open(read_data=''))
-def test_static_node_without_cgroups():
+def test_static_node_with_cgroups_but_require_pids():
     static_node = StaticNode(tasks=['task1'], require_pids=True)
     assert static_node.get_tasks() == []

--- a/tests/extra/test_static_node.py
+++ b/tests/extra/test_static_node.py
@@ -15,9 +15,11 @@ from unittest.mock import Mock, patch
 
 from owca.extra.static_node import StaticNode
 from owca.nodes import Task
+from owca.testing import mock_open
 
 
 @patch('os.path.exists', Mock(return_value=True))
+@patch('builtins.open', mock_open(read_data='100'))
 def test_static_node():
     static_node = StaticNode(tasks=['task1'])
     assert static_node.get_tasks() == [Task(
@@ -27,6 +29,13 @@ def test_static_node():
 
 
 @patch('os.path.exists', Mock(return_value=False))
+@patch('builtins.open', mock_open(read_data='100'))
 def test_static_node_without_cgroups():
     static_node = StaticNode(tasks=['task1'])
+    assert static_node.get_tasks() == []
+
+@patch('os.path.exists', Mock(return_value=True))
+@patch('builtins.open', mock_open(read_data=''))
+def test_static_node_without_cgroups():
+    static_node = StaticNode(tasks=['task1'], require_pids=True)
     assert static_node.get_tasks() == []

--- a/tests/test_containers.py
+++ b/tests/test_containers.py
@@ -142,7 +142,9 @@ def test_sync_containers_state(_, get_pids_mock, sync_mock, perf_counters_mock,
 
     containers_manager = ContainerManager(rdt_enabled=True, rdt_mb_control_enabled=False,
                                           platform_cpus=1,
-                                          allocation_configuration=AllocationConfiguration())
+                                          allocation_configuration=AllocationConfiguration(),
+                                          event_names=[],
+                                          )
     # Put in into ContainerManager our input dict of containers.
     containers_manager.containers = dict(pre_running_containers)
 

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -206,7 +206,7 @@ def test_cleanup(_open_mock, _get_cgroup_fd_mock, os_close_mock):
 def test_open_for_cpu_wrong_arg(_open_mock, _get_cgroup_fd_mock):
     prf = perf.PerfCounters('/mycgroup', [])
     # let's check non-existent type of measurement
-    with pytest.raises(KeyError):
+    with pytest.raises(Exception, match='unknown event name'):
         prf._open_for_cpu(0, 'invalid_event_name')
 
 

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -24,6 +24,7 @@ from owca import metrics
 from owca import perf
 from owca import perf_const as pc
 from owca.metrics import MetricName, DerivedMetricName, DerivedMetricsGenerator
+from owca.perf import _parse_raw_event_name
 from owca.testing import create_open_mock
 
 
@@ -300,6 +301,21 @@ def test_read_broadwell_cpu_model(*args):
 }))
 def test_read_unknown_cpu_model(*args):
     assert pc.CPUModel.UNKNOWN == perf._get_cpu_model()
+
+
+@pytest.mark.parametrize('event_name, expected_attr_config', [
+    ('some__r000000', 0),
+    ('some__r000001', 0x01000000),
+    ('some__r0000ff', 0xff000000),
+    ('some__r0302', 0x00000203),
+    ('some__r0302ff', 0xff000203),
+    ('some__rc000', 0xff000203), # example of Instruction Retired
+
+])
+def test_parse_raw_event_name(event_name, expected_attr_config):
+    got_attr_config = _parse_raw_event_name(event_name)
+    print(hex(got_attr_config))
+    assert got_attr_config == expected_attr_config
 
 
 def test_derived_metrics():

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -350,6 +350,7 @@ def test_derived_metrics():
     assert DerivedMetricName.IPC not in measurements
     assert DerivedMetricName.IPS not in measurements
     assert DerivedMetricName.CACHE_HIT_RATIO not in measurements
+    assert DerivedMetricName.CACHE_MISSES_PER_KILO_INSTRUCTIONS not in measurements
 
     # 5 seconds later
     def gm_func_2():
@@ -366,6 +367,7 @@ def test_derived_metrics():
     assert DerivedMetricName.IPC in measurements
     assert DerivedMetricName.IPS in measurements
     assert DerivedMetricName.CACHE_HIT_RATIO in measurements
+    assert DerivedMetricName.CACHE_MISSES_PER_KILO_INSTRUCTIONS in measurements
 
     assert measurements[DerivedMetricName.IPC] == (10000 / 10)
     assert measurements[DerivedMetricName.IPS] == (10000 / 5)
@@ -373,3 +375,6 @@ def test_derived_metrics():
     # Assuming cache misses increase is 10k over all 50k cache references
     # Cache hit ratio should be 40k / 50k = 80%
     assert measurements[DerivedMetricName.CACHE_HIT_RATIO] == 0.8
+
+    # 10k misses per 10k instructions / 1000 = 10k / 10
+    assert measurements[DerivedMetricName.CACHE_MISSES_PER_KILO_INSTRUCTIONS] == 1000

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -309,13 +309,23 @@ def test_read_unknown_cpu_model(*args):
     ('some__r0000ff', 0xff000000),
     ('some__r0302', 0x00000203),
     ('some__r0302ff', 0xff000203),
-    ('some__rc000', 0xff000203), # example of Instruction Retired
+    ('some__rc000', 0x000000c0),  # example of Instruction Retired
 
 ])
 def test_parse_raw_event_name(event_name, expected_attr_config):
     got_attr_config = _parse_raw_event_name(event_name)
-    print(hex(got_attr_config))
     assert got_attr_config == expected_attr_config
+
+@pytest.mark.parametrize('event_name, expected_match', [
+    ('som', 'contain'),
+    ('some__r00000100', 'length'),
+    ('some__r0000xx', 'invalid literal'),
+    ('some__rxx02', 'invalid literal'),
+
+])
+def test_parse_raw_event_name_invalid(event_name, expected_match):
+    with pytest.raises(Exception, match=expected_match):
+        _parse_raw_event_name(event_name)
 
 
 def test_derived_metrics():

--- a/tests/test_perf.py
+++ b/tests/test_perf.py
@@ -316,6 +316,7 @@ def test_parse_raw_event_name(event_name, expected_attr_config):
     got_attr_config = _parse_raw_event_name(event_name)
     assert got_attr_config == expected_attr_config
 
+
 @pytest.mark.parametrize('event_name, expected_match', [
     ('som', 'contain'),
     ('some__r00000100', 'length'),


### PR DESCRIPTION
Ability to specify which perf events to collection including own raw events from config file.

raw event format is as follows: NAME__rEEUUCC 

where:

    - EE - event selector
    - UU - unit mask
    - CC - counter mask (optionall)

Additional feature:
- static_node may now check if there any pids before returning tasks (to not return empty cgroups)