### PR TITLE
Fix mb schemata write for RDT.

### DIFF
--- a/owca/resctrl_allocations.py
+++ b/owca/resctrl_allocations.py
@@ -240,15 +240,13 @@ class RDTAllocationValue(AllocationValue):
         """Check L3 mask according platform.rdt_ features."""
         if self.rdt_allocation.l3:
             validate_l3_string(self.rdt_allocation.l3,
-                               self.platform_sockets,
                                self.rdt_cbm_mask,
                                self.rdt_min_cbm_bits)
         if self.rdt_allocation.mb:
             if self.rdt_mb_control_enabled is False:
                 raise InvalidAllocations('Allocator requested RDT MB allocation but '
                                          'RDT memory bandwidth is not enabled!')
-            validate_mb_string(self.rdt_allocation.mb,
-                               self.platform_sockets)
+            validate_mb_string(self.rdt_allocation.mb)
 
         self.rdt_groups.validate(self)
 
@@ -355,25 +353,20 @@ def _is_rdt_suballocation_changed(current: Optional[str], new: Optional[str]):
     return False
 
 
-def validate_l3_string(l3, platform_sockets, rdt_cbm_mask, rdt_min_cbm_bits):
+def validate_l3_string(l3, rdt_cbm_mask, rdt_min_cbm_bits):
     assert rdt_cbm_mask is not None
     assert rdt_min_cbm_bits is not None
     if not l3.startswith('L3:'):
         raise InvalidAllocations(
             'l3 resources setting should start with "L3:" prefix (got %r)' % l3)
     domains = _parse_schemata_file_row(l3)
-    if len(domains) != platform_sockets:
-        raise InvalidAllocations('not enough domains in l3 configuration '
-                                 '(expected=%i,got=%i)' % (
-                                     platform_sockets, len(domains)))
-
     for mask_value in domains.values():
         check_cbm_mask(mask_value,
                        rdt_cbm_mask,
                        rdt_min_cbm_bits)
 
 
-def validate_mb_string(mb, platform_sockets):
+def validate_mb_string(mb):
     if not mb.startswith('MB:'):
         raise InvalidAllocations(
             'mb resources setting should start with "MB:" prefix (got %r)' % mb)

--- a/owca/resctrl_allocations.py
+++ b/owca/resctrl_allocations.py
@@ -41,6 +41,7 @@ class RDTGroups:
             self.already_executed_resgroup_names.add(resgroup_name)
             return True
         else:
+            log.debug('RDTGroups: ignore schemata write - already updated!')
             return False
 
     def validate(self, rdt_allocation_value):
@@ -211,12 +212,16 @@ class RDTAllocationValue(AllocationValue):
                                              new.rdt_allocation.l3):
                 new_l3 = new.rdt_allocation.l3
             else:
+                log.debug('changeset l3: no change between: %r and %r' % (
+                    current.rdt_allocation.l3, new.rdt_allocation.l3))
                 new_l3 = None
 
             if _is_rdt_suballocation_changed(current.rdt_allocation.mb,
                                              new.rdt_allocation.mb):
                 new_mb = new.rdt_allocation.mb
             else:
+                log.debug('changeset l3: no change between: %r and %r' % (
+                    current.rdt_allocation.mb, new.rdt_allocation.mb))
                 new_mb = None
 
             if new_l3 or new_mb:
@@ -334,7 +339,7 @@ def _is_rdt_suballocation_changed(current: Optional[str], new: Optional[str]):
         return False
 
     def _is_equal(first, second):
-        return first.lstrip('0') == second.lstrip('0')
+        return first.lstrip(' 0') == second.lstrip(' 0')
 
     current_domains: Dict[str, str] = _parse_schemata_file_row(current)
     new_domains: Dict[str, str] = _parse_schemata_file_row(new)
@@ -372,11 +377,7 @@ def validate_mb_string(mb, platform_sockets):
     if not mb.startswith('MB:'):
         raise InvalidAllocations(
             'mb resources setting should start with "MB:" prefix (got %r)' % mb)
-    domains = _parse_schemata_file_row(mb)
-    if len(domains) != platform_sockets:
-        raise InvalidAllocations('not enough domains in mb configuration '
-                                 '(expected=%i,got=%i)' % (
-                                     platform_sockets, len(domains)))
+    _parse_schemata_file_row(mb)
 
 
 def _count_enabled_bits(hexstr: str) -> int:

--- a/owca/runners/allocation.py
+++ b/owca/runners/allocation.py
@@ -256,12 +256,12 @@ class AllocationRunner(MeasurementRunner):
 
         try:
             if root_rdt_l3 is not None:
-                validate_l3_string(root_rdt_l3,
+                validate_l3_string(root_rdt_l3, platform.sockets,
                                    platform.rdt_information.cbm_mask,
                                    platform.rdt_information.min_cbm_bits)
 
             if root_rdt_mb is not None:
-                validate_mb_string(root_rdt_mb)
+                validate_mb_string(root_rdt_mb, platform.sockets)
 
             resctrl.cleanup_resctrl(root_rdt_l3, root_rdt_mb, self._remove_all_resctrl_groups)
         except InvalidAllocations as e:

--- a/owca/runners/allocation.py
+++ b/owca/runners/allocation.py
@@ -26,8 +26,8 @@ from owca.containers import ContainerInterface, Container
 from owca.detectors import convert_anomalies_to_metrics, \
     update_anomalies_metrics_with_task_information
 from owca.kubernetes import have_tasks_qos_label, are_all_tasks_of_single_qos
-from owca.nodes import Task
 from owca.metrics import Metric, MetricType
+from owca.nodes import Task
 from owca.resctrl_allocations import (RDTAllocationValue, RDTGroups, validate_mb_string,
                                       validate_l3_string)
 from owca.runners.detection import AnomalyStatistics
@@ -256,12 +256,12 @@ class AllocationRunner(MeasurementRunner):
 
         try:
             if root_rdt_l3 is not None:
-                validate_l3_string(root_rdt_l3, platform.sockets,
+                validate_l3_string(root_rdt_l3,
                                    platform.rdt_information.cbm_mask,
                                    platform.rdt_information.min_cbm_bits)
 
             if root_rdt_mb is not None:
-                validate_mb_string(root_rdt_mb, platform.sockets)
+                validate_mb_string(root_rdt_mb)
 
             resctrl.cleanup_resctrl(root_rdt_l3, root_rdt_mb, self._remove_all_resctrl_groups)
         except InvalidAllocations as e:

--- a/tests/resctrl/test_resctrl_allocations.py
+++ b/tests/resctrl/test_resctrl_allocations.py
@@ -21,7 +21,7 @@ from owca.allocations import InvalidAllocations
 from owca.allocators import RDTAllocation
 from owca.resctrl import ResGroup
 from owca.resctrl_allocations import RDTAllocationValue, RDTGroups, _parse_schemata_file_row, \
-    _count_enabled_bits, check_cbm_mask, _is_rdt_suballocation_changed
+    _count_enabled_bits, check_cbm_mask, _is_rdt_suballocation_changed, _validate_domains
 from owca.testing import create_open_mock, allocation_metric
 
 
@@ -244,3 +244,27 @@ def test_check_cbm_bits_gap(mask: str, cbm_mask: str, min_cbm_bits: str,
                             expected_error_message: str):
     with pytest.raises(InvalidAllocations, match=expected_error_message):
         check_cbm_mask(mask, cbm_mask, min_cbm_bits)
+
+
+@pytest.mark.parametrize(
+    'domains, platform_sockets', [
+        ([], 0),
+        ([], 5),
+        (['3'], 4),
+        (['0', '1', '2', '3'], 4),
+    ]
+)
+def test_validate_domain_ok(domains, platform_sockets):
+    _validate_domains(domains, platform_sockets)
+
+
+@pytest.mark.parametrize(
+    'domains, platform_sockets, exception_match', [
+        (['3'], 0, 'range'),
+        (['1', '6'], 5, 'range'),
+        (['xx'], 4, 'numeric'),
+    ]
+)
+def test_validate_domain_invalid(domains, platform_sockets, exception_match):
+    with pytest.raises(InvalidAllocations, match=exception_match):
+        _validate_domains(domains, platform_sockets)

--- a/tests/resctrl/test_resctrl_allocations.py
+++ b/tests/resctrl/test_resctrl_allocations.py
@@ -192,7 +192,9 @@ def test_parse_schemata_file_row(line, expected_domains):
         #   but still expected_result is False.
         (('L3:0=00f;1=00f', 'L3:0=00f'), False),
         (('L3:0=00f;1=00ff', 'L3:0=0000f'), False),
-        # Differening with ending 0, should return True.
+        # No change for left filled with spaces as well.
+        (('L3:0= 00f;1=00ff', 'L3:0=  0000f'), False),
+        # Differencing with ending 0, should return True.
         (('L3:0=00f;1=00f', 'L3:0=00f0;1=00f0'), True),
         # The new allocation is not provided (None).
         (('L3:0=00f0;1=00f0', None), False),


### PR DESCRIPTION
Two fixes:
- do not detect change if 'rdt value' (both l3 or mb) is left prefixed with either ' ' or '0' (this is how schemata write works)
- allow to specify just one domain to update (do not require all) and add domain id validation