### PR TITLE
Add two additional metrics labels cpu_model and initial_task_cpu.

### DIFF
--- a/owca/kubernetes.py
+++ b/owca/kubernetes.py
@@ -179,6 +179,8 @@ _RESOURCE_TYPES = ['requests', 'limits']
 
 
 def _calculate_pod_resources(containers_spec: List[Dict[str, str]]):
+    """Returns flat dictionary with keys created as resource_name + '_' + resource_type,
+       e.g. 'cpu_limits': '0.25' """
     resources = dict()
 
     units = {'memory': _MEMORY_UNITS,  'ephemeral-storage': _MEMORY_UNITS,

--- a/owca/mesos.py
+++ b/owca/mesos.py
@@ -118,7 +118,7 @@ class MesosNode(Node):
 
             labels = {label['key']: label['value'] for label in launched_task['labels']['labels']}
 
-            # Extract scalar resoruces.
+            # Extract scalar resources.
             resources = dict()
             for resource in launched_task['resources']:
                 if resource['type'] == 'SCALAR':

--- a/owca/platforms.py
+++ b/owca/platforms.py
@@ -50,6 +50,19 @@ def get_owca_version():
     return version
 
 
+def get_cpu_model():
+    """Returns information about cpu model from /proc/cpuinfo."""
+    if os.path.isfile('/proc/cpuinfo'):
+        with open('/proc/cpuinfo') as fref:
+            for line in fref.readlines():
+                if line.startswith("model name"):
+                    s = re.search("model name\\s*:\\s*(.*)\\s*$", line)
+                    if s:
+                        return s.group(1)
+                    break
+    return "unknown_cpu_model"
+
+
 @dataclass
 class RDTInformation:
     cbm_mask: Optional[str]  # based on /sys/fs/resctrl/info/L3/cbm_mask
@@ -112,6 +125,7 @@ def create_labels(platform: Platform) -> Dict[str, str]:
     # Additional labels
     labels["host"] = socket.gethostname()
     labels["owca_version"] = get_owca_version()
+    labels["cpu_model"] = get_cpu_model()
     return labels
 
 

--- a/owca/runners/measurement.py
+++ b/owca/runners/measurement.py
@@ -227,6 +227,12 @@ def _prepare_tasks_data(containers: Dict[Task, Container]) -> \
         }
         task_labels['task_id'] = task.task_id
 
+        # Add additional label with cpu initial assignment, to simplify
+        # management of distributed model system for plugin:
+        # https://github.com/intel/platform-resource-manager/tree/master/prm
+        task_labels['initial_task_cpu_assignment'] = \
+            str(task.resources.get('cpus', task.resources.get('cpu_limits', "unknown")))
+
         # Aggregate over all tasks.
         tasks_labels[task.task_id] = task_labels
         tasks_measurements[task.task_id] = task_measurements

--- a/tests/runners/test_runners_measurement.py
+++ b/tests/runners/test_runners_measurement.py
@@ -85,4 +85,6 @@ def test_prepare_tasks_data(*mocks):
 
     assert tasks_measurements == {'t1_task_id': {'cpu_usage': 13}}
     assert tasks_resources == {'t1_task_id': {'cpu': 3}}
-    assert tasks_labels == {'t1_task_id': {'label_key': 'label_value', 'task_id': 't1_task_id'}}
+    assert tasks_labels == {'t1_task_id': {'initial_task_cpu_assignment': 'unknown',
+                                           'label_key': 'label_value',
+                                           'task_id': 't1_task_id'}}

--- a/tests/test_platforms.py
+++ b/tests/test_platforms.py
@@ -107,6 +107,7 @@ def test_collect_topology_information_2_cores_per_socket_all_cpus_online(*mocks)
     "/sys/fs/resctrl/schemata": "MB:0=100",
     "/proc/stat": "parsed value mocked below",
     "/proc/meminfo": "parsed value mocked below",
+    "/proc/cpuinfo": "model name : intel xeon"
 }))
 @patch('owca.platforms.get_owca_version', return_value="0.1")
 @patch('socket.gethostname', return_value="test_host")
@@ -129,5 +130,6 @@ def test_collect_platform_information(*mocks):
                 name=MetricName.CPU_USAGE_PER_CPU, value=200, labels={"cpu": "1"}
             ),
         ],
-        {"sockets": "1", "cores": "1", "cpus": "2", "host": "test_host", "owca_version": "0.1"}
+        {"sockets": "1", "cores": "1", "cpus": "2", "host": "test_host",
+         "owca_version": "0.1", "cpu_model": "intel xeon"}
     )


### PR DESCRIPTION
Add additional label with cpu initial assignment, to simplify
management of distributed model system for plugin:
https://github.com/intel/platform-resource-manager/tree/master/prm

Its workaround and that solution should be removed. But it seems
that to make a proper solution the API needs to be changed.